### PR TITLE
Implement permalink and planner features

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,10 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ***
 
 ## 📋 Changelog
+### Version 1.6.6 (2025-07-21)
+* **Permalinks:** Task links now include the post ID for easier reference.
+* **Template:** Added front-end task view with timer and manual entry (authors+ only).
+* **Shortcodes:** New `[daily-planner]` and `[weekly-planner]` shortcodes list upcoming tasks.
 ### Version 1.6.4 (2025-07-20)
 **Bug Fixes**
 * **Fixed:** Reports page reloaded to task list after submitting query

--- a/templates/single-project_task.php
+++ b/templates/single-project_task.php
@@ -1,0 +1,15 @@
+<?php
+get_header();
+
+if ( ! is_user_logged_in() || ! current_user_can( 'edit_posts' ) ) {
+    echo '<p>' . esc_html__( 'You do not have permission to view this task.', 'ptt' ) . '</p>';
+    get_footer();
+    return;
+}
+
+while ( have_posts() ) : the_post();
+    echo '<h1>' . esc_html( get_the_title() ) . '</h1>';
+    echo ptt_get_timer_controls_html( get_the_ID() );
+endwhile;
+
+get_footer();


### PR DESCRIPTION
## Summary
- bump version to 1.6.6
- add post ID to task permalinks with rewrite rule
- render timer controls via reusable function
- include custom single template for tasks
- add daily & weekly planner shortcodes
- document new version in readme

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e5d7c36c0832e9954c166766cfa96