### PR TITLE
Add session timer feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,10 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ***
 
 ## 📋 Changelog
+### Version 1.7.1 (2025-07-22)
+* **Sessions Save:** Adding a new session now automatically saves the task.
+* **Totals:** Task duration is now calculated from the sum of all sessions.
+* **Validation:** New sessions cannot be created while previous ones are incomplete.
 ### Version 1.7.0 (2025-07-22)
 * **Sessions:** Tasks now support multiple work sessions via a repeater in the admin editor.
 * **Automatic Stop:** Starting a new session automatically stops any prior running session for that task.

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,9 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ***
 
 ## 📋 Changelog
+### Version 1.7.0 (2025-07-22)
+* **Sessions:** Tasks now support multiple work sessions via a repeater in the admin editor.
+* **Automatic Stop:** Starting a new session automatically stops any prior running session for that task.
 ### Version 1.6.7 (2025-07-21)
 * **Status Taxonomy:** Tasks now include a Task Status with default terms.
 * **Reports/Tasks:** New Status column and filtering options.

--- a/scripts.js
+++ b/scripts.js
@@ -180,6 +180,114 @@ jQuery(document).ready(function ($) {
         });
     }
 
+    function initSessionRows($context) {
+        $context = $context || $(document);
+        $context.find('.ptt-session-timer').each(function() {
+            const $container = $(this);
+            if ($container.data('initialized')) return;
+            $container.data('initialized', true);
+
+            const $row = $container.closest('.acf-row');
+            const $startInput = $row.find('[data-key="field_ptt_session_start_time"] input');
+            const $stopInput = $row.find('[data-key="field_ptt_session_stop_time"] input');
+
+            const controlsHtml = '<div class="ptt-session-controls">' +
+                '<button type="button" class="button ptt-session-start">Start Session</button>' +
+                '<button type="button" class="button ptt-session-stop">Stop Session</button>' +
+                '<div class="ptt-ajax-spinner"></div><div class="ptt-ajax-message"></div>' +
+            '</div>';
+            $container.find('.acf-input > p').html(controlsHtml);
+
+            function updateButtons() {
+                const startVal = $startInput.val();
+                const stopVal = $stopInput.val();
+                if (!startVal) {
+                    $container.find('.ptt-session-start').show();
+                    $container.find('.ptt-session-stop').hide();
+                } else if (startVal && !stopVal) {
+                    $container.find('.ptt-session-start').hide();
+                    $container.find('.ptt-session-stop').show();
+                } else {
+                    $container.find('.ptt-session-start').hide();
+                    $container.find('.ptt-session-stop').hide();
+                }
+            }
+
+            updateButtons();
+            $startInput.on('change', updateButtons);
+            $stopInput.on('change', updateButtons);
+        });
+    }
+
+    initSessionRows();
+    if (window.acf) {
+        window.acf.addAction('append', function($el){
+            initSessionRows($el);
+        });
+    }
+
+    $(document).on('click', '.ptt-session-start', function(e){
+        e.preventDefault();
+        const $btn = $(this);
+        const $row = $btn.closest('.acf-row');
+        const index = $row.index();
+        const postId = $('#post_ID').val();
+        const $container = $btn.closest('.ptt-session-controls');
+        $btn.prop('disabled', true);
+        showSpinner($container);
+
+        $.post(ptt_ajax_object.ajax_url, {
+            action: 'ptt_start_session_timer',
+            nonce: ptt_ajax_object.nonce,
+            post_id: postId,
+            row_index: index
+        }).done(function(response){
+            if(response.success){
+                showMessage($container, response.data.message, false);
+                setTimeout(function(){ window.location.reload(); }, 1000);
+            } else {
+                showMessage($container, response.data.message, true);
+                $btn.prop('disabled', false);
+            }
+        }).fail(function(){
+            showMessage($container, 'An unexpected error occurred.', true);
+            $btn.prop('disabled', false);
+        }).always(function(){
+            hideSpinner($container);
+        });
+    });
+
+    $(document).on('click', '.ptt-session-stop', function(e){
+        e.preventDefault();
+        const $btn = $(this);
+        const $row = $btn.closest('.acf-row');
+        const index = $row.index();
+        const postId = $('#post_ID').val();
+        const $container = $btn.closest('.ptt-session-controls');
+        $btn.prop('disabled', true);
+        showSpinner($container);
+
+        $.post(ptt_ajax_object.ajax_url, {
+            action: 'ptt_stop_session_timer',
+            nonce: ptt_ajax_object.nonce,
+            post_id: postId,
+            row_index: index
+        }).done(function(response){
+            if(response.success){
+                showMessage($container, response.data.message, false);
+                setTimeout(function(){ window.location.reload(); }, 1000);
+            } else {
+                showMessage($container, response.data.message, true);
+                $btn.prop('disabled', false);
+            }
+        }).fail(function(){
+            showMessage($container, 'An unexpected error occurred.', true);
+            $btn.prop('disabled', false);
+        }).always(function(){
+            hideSpinner($container);
+        });
+    });
+
 
     /**
      * ---------------------------------------------------------------

--- a/scripts.js
+++ b/scripts.js
@@ -56,13 +56,48 @@ jQuery(document).ready(function ($) {
             .fadeOut('slow');
     }
 
-    function showMessageWithHTML($container, html, isError) {
-        $container.find('.ptt-ajax-message')
-            .html(html)
-            .removeClass('success error')
-            .addClass(isError ? 'error' : 'success')
-            .show();
-    }
+function showMessageWithHTML($container, html, isError) {
+    $container.find('.ptt-ajax-message')
+        .html(html)
+        .removeClass('success error')
+        .addClass(isError ? 'error' : 'success')
+        .show();
+}
+
+function validateSessionRows() {
+    let valid = true;
+    $('.acf-field[data-key="field_ptt_sessions"] .acf-row').each(function(){
+        const $row = $(this);
+        const title = $row.find('[data-key="field_ptt_session_title"] input').val();
+        const notes = $row.find('[data-key="field_ptt_session_notes"] textarea').val();
+        const start = $row.find('[data-key="field_ptt_session_start_time"] input').val();
+        const stop = $row.find('[data-key="field_ptt_session_stop_time"] input').val();
+        const override = $row.find('[data-key="field_ptt_session_manual_override"] input').prop('checked');
+        const manual = $row.find('[data-key="field_ptt_session_manual_duration"] input').val();
+
+        if (!title || !notes) {
+            valid = false;
+            return false;
+        }
+
+        if (override) {
+            if (manual === '' || manual === null) {
+                valid = false;
+                return false;
+            }
+        } else {
+            if (!start || !stop) {
+                valid = false;
+                return false;
+            }
+            if (start && !stop) {
+                valid = false;
+                return false;
+            }
+        }
+    });
+    return valid;
+}
 
 
     /**
@@ -225,6 +260,18 @@ jQuery(document).ready(function ($) {
             initSessionRows($el);
         });
     }
+
+    $(document).on('click', '.acf-field[data-key="field_ptt_sessions"] [data-event="add-row"], .acf-field[data-key="field_ptt_sessions"] [data-name="add-row"]', function(e){
+        if (!validateSessionRows()) {
+            e.preventDefault();
+            alert('Please complete all session fields and stop running timers before adding another session.');
+            return false;
+        }
+        const $btn = $('#publish');
+        if ($btn.length) {
+            setTimeout(function(){ $btn.trigger('click'); }, 100);
+        }
+    });
 
     $(document).on('click', '.ptt-session-start', function(e){
         e.preventDefault();

--- a/styles.css
+++ b/styles.css
@@ -57,6 +57,10 @@
     color: #d94848;
 }
 
+.ptt-session-controls {
+    margin-top: 8px;
+}
+
 /* --- Frontend Shortcode Styles --- */
 .ptt-frontend-container {
     max-width: 600px;


### PR DESCRIPTION
## Summary
- register ACF repeater for per-task sessions
- calculate session durations and manage active sessions
- add AJAX handlers and JS UI for starting/stopping session timers
- bump version to 1.7.0
- document new feature in the changelog

## Testing
- `php self-test.php` *(fails: requires WP context)*

------
https://chatgpt.com/codex/tasks/task_b_687ed5eb85a0832e912f469c6337fd7d