### PR TITLE
2025 07 21 session start stop buttons

### DIFF
--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.6.7
+ * Version:           1.6.8
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.6.7' );
+define( 'PTT_VERSION', '1.6.8' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.6.2
+ * Version:           1.6.3
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.6.2' );
+define( 'PTT_VERSION', '1.6.3' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.6.3
+ * Version:           1.6.4
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.6.3' );
+define( 'PTT_VERSION', '1.6.4' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.2
+ * Version:           1.7.3
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.2' );
+define( 'PTT_VERSION', '1.7.3' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -754,8 +754,7 @@ function ptt_add_start_stop_buttons() {
     $post_id = $post->ID;
     echo ptt_get_timer_controls_html( $post_id );
 }
-//Disabled for now since there are multiple sessions
-//add_action( 'post_submitbox_misc_actions', 'ptt_add_start_stop_buttons' );
+// add_action( 'post_submitbox_misc_actions', 'ptt_add_start_stop_buttons' );
 
 /**
  * Adds a Status column to the Tasks list table.

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.6.6
+ * Version:           1.6.7
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.6.6' );
+define( 'PTT_VERSION', '1.6.7' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -57,6 +57,14 @@ function ptt_activate() {
     // Register CPT and Taxonomies to make them available.
     ptt_register_post_type();
     ptt_register_taxonomies();
+
+    // Ensure default Task Status terms exist
+    $default_statuses = [ 'In Progress', 'Completed', 'Paused' ];
+    foreach ( $default_statuses as $status ) {
+        if ( ! term_exists( $status, 'task_status' ) ) {
+            wp_insert_term( $status, 'task_status' );
+        }
+    }
 
     // Create a baseline test post.
     if ( ! get_page_by_title( 'Test First Task', OBJECT, 'project_task' ) ) {
@@ -223,6 +231,28 @@ function ptt_register_taxonomies() {
         'rewrite'           => [ 'slug' => 'project' ],
     ];
     register_taxonomy( 'project', [ 'project_task' ], $project_args );
+
+    // Task Status Taxonomy
+    $status_labels = [
+        'name'              => _x( 'Statuses', 'taxonomy general name', 'ptt' ),
+        'singular_name'     => _x( 'Status', 'taxonomy singular name', 'ptt' ),
+        'search_items'      => __( 'Search Statuses', 'ptt' ),
+        'all_items'         => __( 'All Statuses', 'ptt' ),
+        'edit_item'         => __( 'Edit Status', 'ptt' ),
+        'update_item'       => __( 'Update Status', 'ptt' ),
+        'add_new_item'      => __( 'Add New Status', 'ptt' ),
+        'new_item_name'     => __( 'New Status Name', 'ptt' ),
+        'menu_name'         => __( 'Task Statuses', 'ptt' ),
+    ];
+    $status_args = [
+        'hierarchical'      => false,
+        'labels'            => $status_labels,
+        'show_ui'           => true,
+        'show_admin_column' => true,
+        'query_var'         => true,
+        'rewrite'           => [ 'slug' => 'task_status' ],
+    ];
+    register_taxonomy( 'task_status', [ 'project_task' ], $status_args );
 }
 add_action( 'init', 'ptt_register_taxonomies' );
 
@@ -536,6 +566,36 @@ function ptt_add_start_stop_buttons() {
 }
 add_action( 'post_submitbox_misc_actions', 'ptt_add_start_stop_buttons' );
 
+/**
+ * Adds a Status column to the Tasks list table.
+ *
+ * @param array $columns Existing columns.
+ * @return array Modified columns.
+ */
+function ptt_add_status_column( $columns ) {
+    $columns['task_status'] = 'Status';
+    return $columns;
+}
+add_filter( 'manage_project_task_posts_columns', 'ptt_add_status_column' );
+
+/**
+ * Renders the Status column content.
+ *
+ * @param string $column  Column name.
+ * @param int    $post_id Post ID.
+ */
+function ptt_render_status_column( $column, $post_id ) {
+    if ( 'task_status' === $column ) {
+        $terms = get_the_terms( $post_id, 'task_status' );
+        if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
+            echo esc_html( implode( ', ', wp_list_pluck( $terms, 'name' ) ) );
+        } else {
+            echo '&#8212;';
+        }
+    }
+}
+add_action( 'manage_project_task_posts_custom_column', 'ptt_render_status_column', 10, 2 );
+
 
 // =================================================================
 // 8.0 AJAX HANDLERS
@@ -625,7 +685,15 @@ function ptt_start_timer_callback() {
     // This is useful if an admin creates a a task and a developer starts it
     wp_update_post( ['ID' => $post_id, 'post_author' => $user_id] );
 
-    wp_send_json_success( [ 'message' => 'Timer started!', 'start_time' => $current_time, 'post_id' => $post_id ] );
+    $status_terms = get_the_terms( $post_id, 'task_status' );
+    $status_name  = ! is_wp_error( $status_terms ) && $status_terms ? $status_terms[0]->name : '';
+
+    wp_send_json_success( [
+        'message'     => 'Timer started!',
+        'start_time'  => $current_time,
+        'post_id'     => $post_id,
+        'task_status' => $status_name,
+    ] );
 }
 add_action( 'wp_ajax_ptt_start_timer', 'ptt_start_timer_callback' );
 
@@ -646,12 +714,15 @@ function ptt_get_active_task_info_callback() {
         wp_send_json_error(['message' => 'No active task found.']);
     }
 
-    $start_time = get_field('start_time', $active_task_id);
+    $start_time    = get_field( 'start_time', $active_task_id );
+    $status_terms  = get_the_terms( $active_task_id, 'task_status' );
+    $status_name   = ! is_wp_error( $status_terms ) && $status_terms ? $status_terms[0]->name : '';
 
     wp_send_json_success([
-        'post_id'    => $active_task_id,
-        'task_name'  => get_the_title($active_task_id),
-        'start_time' => $start_time,
+        'post_id'     => $active_task_id,
+        'task_name'   => get_the_title( $active_task_id ),
+        'start_time'  => $start_time,
+        'task_status' => $status_name,
     ]);
 }
 add_action('wp_ajax_ptt_get_active_task_info', 'ptt_get_active_task_info_callback');

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.3
+ * Version:           1.7.4
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.3' );
+define( 'PTT_VERSION', '1.7.4' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.1
+ * Version:           1.7.2
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.1' );
+define( 'PTT_VERSION', '1.7.2' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -494,11 +494,12 @@ function ptt_enqueue_assets() {
     
     // Localize script to pass data like nonces and AJAX URL
     wp_localize_script( 'ptt-scripts', 'ptt_ajax_object', [
-        'ajax_url' => admin_url( 'admin-ajax.php' ),
-        'nonce'    => wp_create_nonce( 'ptt_ajax_nonce' ),
-        'confirm_stop' => __('Are you sure you want to stop the timer?', 'ptt'),
-        'concurrent_error' => __('You have another task running. Please stop it before starting a new one.', 'ptt'),
-        'edit_post_link' => admin_url('post.php?action=edit&post='), // Add this line
+        'ajax_url'              => admin_url( 'admin-ajax.php' ),
+        'nonce'                 => wp_create_nonce( 'ptt_ajax_nonce' ),
+        'confirm_stop'          => __('Are you sure you want to stop the timer?', 'ptt'),
+        'concurrent_error'      => __('You have another task running. Please stop it before starting a new one.', 'ptt'),
+        'edit_post_link'        => admin_url('post.php?action=edit&post='),
+        'todays_date_formatted' => date_i18n( get_option( 'date_format' ), current_time( 'timestamp' ) ),
     ]);
 }
 // Enqueue for admin screens
@@ -753,7 +754,8 @@ function ptt_add_start_stop_buttons() {
     $post_id = $post->ID;
     echo ptt_get_timer_controls_html( $post_id );
 }
-add_action( 'post_submitbox_misc_actions', 'ptt_add_start_stop_buttons' );
+//Disabled for now since there are multiple sessions
+//add_action( 'post_submitbox_misc_actions', 'ptt_add_start_stop_buttons' );
 
 /**
  * Adds a Status column to the Tasks list table.

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,10 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ***
 
 ## 📋 Changelog
+### Version 1.6.4 (2025-07-20)
+**Bug Fixes**
+* **Fixed:** Reports page reloaded to task list after submitting query
+
 ### Version 1.6.3 (2025-07-20)
 **Sharable Reports**
 * **Added:** URL parameters for reports (user, client, project, dates)

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 * **Custom Post Type:** A dedicated "Tasks" CPT (`project_task`) to manage all work items.
 * **Custom Taxonomies:** Organize tasks by "Clients" and "Projects".
 * **Budgeting & Deadlines:** Set a maximum hour budget and a deadline for both entire projects and individual tasks.
+* **Dated Titles:** A "Use Today's Date" button in the task editor prepends the current date to the title for quick entry.
 
 ### Time Tracking
 * **Start/Stop Timer:** Simple one-click Start/Stop buttons in the task editor.
@@ -49,6 +50,7 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 * **Reports Dashboard:** A dedicated "Reports" page in the admin area.
 * **Filterable Data:** Filter reports by user and custom date ranges.
 * **Grouped Results:** Data is logically grouped by User, Client, and Project, with subtotals for each.
+* **Over-Budget Highlighting:** The "Orig. Budget" column automatically highlights entries in red if the tracked time exceeds the allocated budget.
 * **Developer Self-Test:** A built-in testing module to verify core functionality.
 
 ***
@@ -58,7 +60,10 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ### 1. Planning Projects and Tasks
 1.  Navigate to **Tasks → Projects** to create your projects. Here you can set a **Maximum Budget** and **Deadline** for the entire project.
 2.  Navigate to **Tasks → Clients** to create your clients.
-3.  Navigate to **Tasks → Add New Task** to create individual tasks for your team. Assign them to a Client and Project, and set the specific **Maximum Budget** and **Deadline** for that task.
+3.  Navigate to **Tasks → Add New Task** to create individual tasks.
+    * Click the **"Use Today's Date"** button to automatically add the current date to the title.
+    * Assign the task to a Client and Project.
+    * Set the specific **Maximum Budget** and **Deadline** for that task.
 
 ### 2. Tracking Time (Front-End)
 1.  Add the shortcode `[task-enter]` to any page.
@@ -76,11 +81,15 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ### 4. Viewing Reports
 1.  Navigate to **Reports** from the main admin menu.
 2.  Select a user and/or date range.
-3.  Click **Run Report** to see a detailed breakdown of time tracked.
+3.  Click **Run Report** to see a detailed breakdown of time tracked. Note any items in red under the "Orig. Budget" column, as these have exceeded their budget.
 
 ***
 
 ## 📋 Changelog
+### Version 1.7.2 (2025-07-21)
+* **Feature:** Orig. Budget amount in reports now appears in red if the task duration exceeds the budget.
+* **Feature:** Added a "Use Today's Date" button next to the post title field on the Add/Edit Task screen to quickly prepend the current date.
+
 ### Version 1.7.1 (2025-07-22)
 * **Sessions Save:** Adding a new session now automatically saves the task.
 * **Totals:** Task duration is now calculated from the sum of all sessions.

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,10 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ***
 
 ## 📋 Changelog
+### Version 1.7.1 (2025-07-22)
+* **Sessions Save:** Adding a new session now automatically saves the task.
+* **Totals:** Task duration is now calculated from the sum of all sessions.
+* **Validation:** New sessions cannot be created while previous ones are incomplete.
 ### Version 1.7.0 (2025-07-22)
 * **Sessions:** Tasks now support multiple work sessions via a repeater in the admin editor.
 * **Automatic Stop:** Starting a new session automatically stops any prior running session for that task.

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,9 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ***
 
 ## 📋 Changelog
+### Version 1.7.0 (2025-07-22)
+* **Sessions:** Tasks now support multiple work sessions via a repeater in the admin editor.
+* **Automatic Stop:** Starting a new session automatically stops any prior running session for that task.
 ### Version 1.6.7 (2025-07-21)
 * **Status Taxonomy:** Tasks now include a Task Status with default terms.
 * **Reports/Tasks:** New Status column and filtering options.

--- a/readme.md
+++ b/readme.md
@@ -18,12 +18,8 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 
 1.  Download the plugin folder `project-task-tracker`.
 2.  Upload the entire `project-task-tracker` folder to the `/wp-content/plugins/` directory on your server.
-3.  The folder should contain the following three files in its root:
-    * `project-task-tracker.php`
-    * `styles.css`
-    * `scripts.js`
-4.  Activate the plugin through the 'Plugins' menu in your WordPress admin dashboard.
-5.  ACF Pro (Premium/paid) plugin is required and needs to be activated. The necessary custom fields will be created automatically.
+3.  Activate the plugin through the 'Plugins' menu in your WordPress admin dashboard.
+4.  Ensure ACF Pro is also installed and activated. The necessary custom fields will be created automatically.
 
 ***
 
@@ -32,11 +28,12 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ### Project & Task Management
 * **Custom Post Type:** A dedicated "Tasks" CPT (`project_task`) to manage all work items.
 * **Custom Taxonomies:** Organize tasks by "Clients" and "Projects".
+* **Multi-Session Tracking:** Each task can have multiple work sessions, allowing for detailed time logs.
 * **Budgeting & Deadlines:** Set a maximum hour budget and a deadline for both entire projects and individual tasks.
 * **Dated Titles:** A "Use Today's Date" button in the task editor prepends the current date to the title for quick entry.
 
 ### Time Tracking
-* **Start/Stop Timer:** Simple one-click Start/Stop buttons in the task editor.
+* **Live Session Timers:** Simple one-click Start/Stop buttons in each session row in the task editor, with a live updating timer.
 * **Automatic Calculation:** Duration is automatically calculated in decimal format (e.g., 1.75 hours) and rounded up to two decimal places.
 * **Timezone Support:** All time entries respect the timezone set in your WordPress settings.
 * **Concurrent Task Prevention:** A user is prevented from starting a new task if another one is already running.
@@ -48,7 +45,7 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 
 ### Reporting & Admin Tools
 * **Reports Dashboard:** A dedicated "Reports" page in the admin area.
-* **Filterable Data:** Filter reports by user and custom date ranges.
+* **Filterable Data:** Filter reports by user, client, project, status, and custom date ranges.
 * **Grouped Results:** Data is logically grouped by User, Client, and Project, with subtotals for each.
 * **Over-Budget Highlighting:** The "Orig. Budget" column automatically highlights entries in red if the tracked time exceeds the allocated budget.
 * **Developer Self-Test:** A built-in testing module to verify core functionality.
@@ -57,44 +54,93 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 
 ## 📖 How to Use
 
-### 1. Planning Projects and Tasks
-1.  Navigate to **Tasks → Projects** to create your projects. Here you can set a **Maximum Budget** and **Deadline** for the entire project.
-2.  Navigate to **Tasks → Clients** to create your clients.
-3.  Navigate to **Tasks → Add New Task** to create individual tasks.
-    * Click the **"Use Today's Date"** button to automatically add the current date to the title.
-    * Assign the task to a Client and Project.
-    * Set the specific **Maximum Budget** and **Deadline** for that task.
+The workflow is designed to be flexible. You can create tasks first and track time later, or create them on-the-fly.
 
-### 2. Tracking Time (Front-End)
-1.  Add the shortcode `[task-enter]` to any page.
-2.  A logged-in user (Editor, Author, Admin) can visit this page.
-3.  They will select a Client, then a Project.
-4.  The "Select Task" dropdown will populate with all available tasks for that project.
-5.  Upon selecting a task, they'll see the budget and can click **Start Timer**.
-6.  To stop the timer, they can revisit the page, where an "Active Task" module will appear with a **Stop Timer** button.
+### 1. How to Add a Task
 
-### 3. Tracking Time (Back-End)
-1.  Navigate to **Tasks → All Tasks** and edit the desired task.
-2.  In the "Publish" meta box on the right, click the green **Start Timer** button.
-3.  When finished, edit the task again and click the red **Stop Timer** button.
+1.  Navigate to **Tasks → Add New Task**.
+2.  **(Optional)** Click the **"Use Today's Date"** button located under the title field to automatically prepend today's date to your task title. This is useful for daily logs.
+3.  Enter a descriptive **Title** for the task (e.g., "Design homepage mockup").
+4.  Use the main content editor to add any notes, descriptions, or links related to the task. This content will appear in the "Notes" column of the reports.
+5.  On the right-hand side, assign the task to a **Client** and a **Project**.
+6.  In the "Task Details" section below the content editor, you can set a **Maximum Budget (Hours)** and a **Task Deadline**.
 
-### 4. Viewing Reports
-1.  Navigate to **Reports** from the main admin menu.
-2.  Select a user and/or date range.
-3.  Click **Run Report** to see a detailed breakdown of time tracked. Note any items in red under the "Orig. Budget" column, as these have exceeded their budget.
+### 2. How to Track Time
+
+You can track time for a task in two ways: using the live timer or entering it manually. This is done via **Sessions**. Each task can have multiple sessions.
+
+#### Adding a New Session
+
+1.  Edit an existing task.
+2.  Scroll down to the "Sessions" panel.
+3.  Click the **"Add Session"** button.
+    * **Note:** You must stop any currently running timers in other sessions before you can add a new one. The plugin will prompt you if you need to complete an existing session.
+4.  A new, empty session row will appear. Enter a **Session Title** (e.g., "Initial research") and any **Notes** for that specific work block.
+
+#### Using the Live Timer (Recommended)
+
+1.  In a new or existing session row, find the **Timer** column.
+2.  Click the blue **"Start Timer"** button.
+3.  The button will be replaced by a live, ticking timer showing elapsed hours, minutes, and seconds, along with a red **"Stop Timer"** button. You can leave the page; the start time is saved.
+4.  When you are finished working, return to the task editor and click the **"Stop Timer"** button.
+5.  The session will be saved, the final duration will be calculated, and the post will be updated automatically.
+
+#### Manually Adding Time
+
+This is useful if you forgot to start a timer and need to log time after the fact.
+
+1.  In a session row, check the **"Manual Time Entry"** toggle.
+2.  The timer controls will be replaced with a **"Manual Duration (Hours)"** field.
+3.  Enter the time spent in decimal format (e.g., `1.5` for 1 hour and 30 minutes, `0.25` for 15 minutes).
+4.  Save the task by clicking **"Update"**. The manually entered duration will be added to the task's total.
+
+### 3. Viewing Reports
+
+1.  Navigate to **Tasks → Reports** from the admin menu.
+2.  Use the filters at the top to select a user, client, project, status, or date range.
+3.  Click **"Run Report"**.
+4.  The results will be grouped by user, then client, then project. Note any items in red under the "Orig. Budget" column, as these have exceeded their budget.
+
+***
+
+## ❔ Frequently Asked Questions (FAQ)
+
+**Q: Why do I need ACF Pro?**
+A: This plugin is built on Advanced Custom Fields Pro. It handles all the custom fields for start/stop times, budgets, deadlines, and the session repeater. The plugin will not function without it.
+
+**Q: Can I run two timers at once?**
+A: No. To ensure data integrity, the plugin prevents a user from starting a timer if another task is already running for them. You must stop your active task before starting a new one.
+
+**Q: Why can't I add a new session?**
+A: You must complete any open sessions first. Make sure that every existing session row has either been stopped (with a start and stop time) or has a manual duration entered. You cannot add a new session if a previous one is still running.
+
+**Q: Where do the notes in the reports come from?**
+A: The main notes for a task are pulled from the large content editor of the "Task" post type (the same area where you write a blog post). Notes for individual sessions are not yet included in reports.
+
+**Q: What does "Over Budget" in the reports mean?**
+A: The total time tracked for the task has exceeded the hours you set in the "Maximum Budget" field. The system first checks for a task-specific budget. If one is not set, it falls back to the budget of the parent project. If the text is red, you've gone over the allocated time.
 
 ***
 
 ## 📋 Changelog
+### Version 1.7.4 (2025-07-21)
+* **Docs:** Added detailed user instructions and an FAQ section to the Readme file.
+
+### Version 1.7.3 (2025-07-21)
+* **Feature:** Session rows in the admin editor now have a live, one-click timer.
+* **Feature:** Starting and stopping a session timer no longer requires a page reload.
+* **Improved:** Re-used front-end timer logic for back-end sessions to adhere to DRY principles.
+* **Fixed:** Session validation now correctly checks for running timers before allowing a new session to be added.
+
 ### Version 1.7.2 (2025-07-21)
 * **Feature:** Orig. Budget amount in reports now appears in red if the task duration exceeds the budget.
-* **Feature:** Added a "Use Today's Date" button next to the post title field on the Add/Edit Task screen to quickly prepend the current date.
+* **Feature:** Added a "Use Today's Date" button under the post title field on the Add/Edit Task screen to quickly prepend the current date.
 
-### Version 1.7.1 (2025-07-22)
+### Version 1.7.1 (2025-07-21)
 * **Sessions Save:** Adding a new session now automatically saves the task.
 * **Totals:** Task duration is now calculated from the sum of all sessions.
 * **Validation:** New sessions cannot be created while previous ones are incomplete.
-### Version 1.7.0 (2025-07-22)
+### Version 1.7.0 (2025-07-21)
 * **Sessions:** Tasks now support multiple work sessions via a repeater in the admin editor.
 * **Automatic Stop:** Starting a new session automatically stops any prior running session for that task.
 ### Version 1.6.7 (2025-07-21)

--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ A: The total time tracked for the task has exceeded the hours you set in the "Ma
 ## 📋 Changelog
 ### Version 1.7.4 (2025-07-21)
 * **Docs:** Added detailed user instructions and an FAQ section to the Readme file.
+* **Feature:** On screen debugger code for  timer in scripts.js - comment out later
 
 ### Version 1.7.3 (2025-07-21)
 * **Feature:** Session rows in the admin editor now have a live, one-click timer.

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,10 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ***
 
 ## 📋 Changelog
+### Version 1.6.6 (2025-07-21)
+* **Permalinks:** Task links now include the post ID for easier reference.
+* **Template:** Added front-end task view with timer and manual entry (authors+ only).
+* **Shortcodes:** New `[daily-planner]` and `[weekly-planner]` shortcodes list upcoming tasks.
 ### Version 1.6.4 (2025-07-20)
 **Bug Fixes**
 * **Fixed:** Reports page reloaded to task list after submitting query

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,10 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ***
 
 ## 📋 Changelog
+### Version 1.6.7 (2025-07-21)
+* **Status Taxonomy:** Tasks now include a Task Status with default terms.
+* **Reports/Tasks:** New Status column and filtering options.
+
 ### Version 1.6.6 (2025-07-21)
 * **Permalinks:** Task links now include the post ID for easier reference.
 * **Template:** Added front-end task view with timer and manual entry (authors+ only).

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,11 @@ A robust WordPress plugin for tracking time spent on client projects and individ
 ***
 
 ## 📋 Changelog
+### Version 1.6.3 (2025-07-20)
+**Sharable Reports**
+* **Added:** URL parameters for reports (user, client, project, dates)
+* **Feature:** Reports auto-load based on incoming URL parameters
+
 
 ### Version 1.6.2 (2025-07-20)
 **Budget Display in Reports**

--- a/reports.php
+++ b/reports.php
@@ -10,11 +10,11 @@
  * CHANGELOG (excerpt)
  * ------------------------------------------------------------------
  * 1.6.6 – 2025‑07‑20
- *   • Fixed: Manual time entries (manual_override = 1) were excluded
- *     from reports because they do not always have a stop_time.
- *   • Improved: When a task has no start_time (e.g. imported manual
- *     entries) we now fall back to the post’s publish date so the
- *     report never shows “1970‑01‑01”.
+ * • Fixed: Manual time entries (manual_override = 1) were excluded
+ * from reports because they do not always have a stop_time.
+ * • Improved: When a task has no start_time (e.g. imported manual
+ * entries) we now fall back to the post’s publish date so the
+ * report never shows “1970‑01‑01”.
  * ------------------------------------------------------------------
  */
 
@@ -397,23 +397,31 @@ function ptt_display_report_results() {
 
 				foreach ( $project['tasks'] as $task ) {
 
-					// Budget column display
-					if ( ! empty( $task['task_budget'] ) && $task['task_budget'] > 0 ) {
-						$budget_display = number_format( (float) $task['task_budget'], 2 ) . '&nbsp;(Task)';
-					} elseif ( ! empty( $task['project_budget'] ) && $task['project_budget'] > 0 ) {
-						$budget_display = number_format( (float) $task['project_budget'], 2 ) . '&nbsp;(Project)';
-					} else {
-						$budget_display = '–';
+					// --- Budget column display & color logic ---
+					$effective_budget = 0;
+					$budget_display   = '–';
+
+					if ( ! empty( $task['task_budget'] ) && (float) $task['task_budget'] > 0 ) {
+						$effective_budget = (float) $task['task_budget'];
+						$budget_display   = number_format( $effective_budget, 2 ) . '&nbsp;(Task)';
+					} elseif ( ! empty( $task['project_budget'] ) && (float) $task['project_budget'] > 0 ) {
+						$effective_budget = (float) $task['project_budget'];
+						$budget_display   = number_format( $effective_budget, 2 ) . '&nbsp;(Project)';
+					}
+
+					$budget_td_style = '';
+					if ( $effective_budget > 0 && (float) $task['duration'] > $effective_budget ) {
+						$budget_td_style = 'style="color: #f44336; font-weight: bold;"';
 					}
 
 					echo '<tr>';
 					echo '<td><a href="' . get_edit_post_link( $task['id'] ) . '">' . esc_html( $task['title'] ) . '</a></td>';
 					echo '<td>' . esc_html( date( 'Y-m-d', strtotime( $task['date'] ) ) ) . '</td>';
 					echo '<td>' . number_format( $task['duration'], 2 ) . '</td>';
-                                        echo '<td>' . $budget_display . '</td>';
-                                        echo '<td>' . ptt_format_task_notes( $task['content'] ) . '</td>';
-                                        echo '<td>' . esc_html( $task['status'] ) . '</td>';
-                                        echo '</tr>';
+					echo '<td ' . $budget_td_style . '>' . $budget_display . '</td>';
+					echo '<td>' . ptt_format_task_notes( $task['content'] ) . '</td>';
+					echo '<td>' . esc_html( $task['status'] ) . '</td>';
+					echo '</tr>';
 				}
 
 				echo '</tbody></table></div>'; // .project-group

--- a/reports.php
+++ b/reports.php
@@ -82,6 +82,8 @@ function ptt_reports_page_html() {
         
         <form method="get" action="">
             <?php wp_nonce_field( 'ptt_run_report_nonce' ); ?>
+            <input type="hidden" name="post_type" value="project_task" />
+            <input type="hidden" name="page" value="ptt-reports" />
             <table class="form-table">
                 <tbody>
                     <tr>

--- a/reports.php
+++ b/reports.php
@@ -80,7 +80,7 @@ function ptt_reports_page_html() {
     <div class="wrap">
         <h1>Project & Task Time Reports</h1>
         
-        <form method="post" action="">
+        <form method="get" action="">
             <?php wp_nonce_field( 'ptt_run_report_nonce' ); ?>
             <table class="form-table">
                 <tbody>
@@ -90,7 +90,7 @@ function ptt_reports_page_html() {
                             <?php wp_dropdown_users( [
                                 'name' => 'user_id',
                                 'show_option_all' => 'All Users',
-                                'selected' => isset($_POST['user_id']) ? intval($_POST['user_id']) : 0
+                                'selected' => isset($_REQUEST['user_id']) ? intval($_REQUEST['user_id']) : 0
                             ] ); ?>
                         </td>
                     </tr>
@@ -102,7 +102,7 @@ function ptt_reports_page_html() {
                                 'name'            => 'client_id',
                                 'show_option_all' => 'All Clients',
                                 'hide_empty'      => false,
-                                'selected'        => isset($_POST['client_id']) ? intval($_POST['client_id']) : 0,
+                                'selected'        => isset($_REQUEST['client_id']) ? intval($_REQUEST['client_id']) : 0,
                                 'hierarchical'    => true,
                                 'class'           => '' // Reset class to avoid conflict
                             ] ); ?>
@@ -116,7 +116,7 @@ function ptt_reports_page_html() {
                                 'name'            => 'project_id',
                                 'show_option_all' => 'All Projects',
                                 'hide_empty'      => false,
-                                'selected'        => isset($_POST['project_id']) ? intval($_POST['project_id']) : 0,
+                                'selected'        => isset($_REQUEST['project_id']) ? intval($_REQUEST['project_id']) : 0,
                                 'hierarchical'    => true,
                                 'class'           => '' // Reset class to avoid conflict
                             ] ); ?>
@@ -125,9 +125,9 @@ function ptt_reports_page_html() {
                     <tr>
                         <th scope="row"><label for="start_date">Date Range</label></th>
                         <td>
-                            <input type="date" id="start_date" name="start_date" value="<?php echo isset($_POST['start_date']) ? esc_attr($_POST['start_date']) : ''; ?>">
+                            <input type="date" id="start_date" name="start_date" value="<?php echo isset($_REQUEST['start_date']) ? esc_attr($_REQUEST['start_date']) : ''; ?>">
                             to
-                            <input type="date" id="end_date" name="end_date" value="<?php echo isset($_POST['end_date']) ? esc_attr($_POST['end_date']) : ''; ?>">
+                            <input type="date" id="end_date" name="end_date" value="<?php echo isset($_REQUEST['end_date']) ? esc_attr($_REQUEST['end_date']) : ''; ?>">
                              <button type="button" id="set-this-week" class="button">This Week (Sun-Sat)</button>
                              <button type="button" id="set-last-week" class="button">Last Week</button>
                         </td>
@@ -140,7 +140,7 @@ function ptt_reports_page_html() {
         </form>
 
         <?php
-        if ( isset( $_POST['run_report'] ) ) {
+        if ( isset( $_REQUEST['run_report'] ) ) {
             check_admin_referer( 'ptt_run_report_nonce' );
             ptt_display_report_results();
         }
@@ -153,11 +153,11 @@ function ptt_reports_page_html() {
  * Queries and displays the report results.
  */
 function ptt_display_report_results() {
-    $user_id    = isset( $_POST['user_id'] ) ? intval( $_POST['user_id'] ) : 0;
-    $client_id  = isset( $_POST['client_id'] ) ? intval( $_POST['client_id'] ) : 0;
-    $project_id = isset( $_POST['project_id'] ) ? intval( $_POST['project_id'] ) : 0;
-    $start_date = isset( $_POST['start_date'] ) && $_POST['start_date'] ? sanitize_text_field( $_POST['start_date'] ) : null;
-    $end_date   = isset( $_POST['end_date'] ) && $_POST['end_date'] ? sanitize_text_field( $_POST['end_date'] ) : null;
+    $user_id    = isset( $_REQUEST['user_id'] ) ? intval( $_REQUEST['user_id'] ) : 0;
+    $client_id  = isset( $_REQUEST['client_id'] ) ? intval( $_REQUEST['client_id'] ) : 0;
+    $project_id = isset( $_REQUEST['project_id'] ) ? intval( $_REQUEST['project_id'] ) : 0;
+    $start_date = isset( $_REQUEST['start_date'] ) && $_REQUEST['start_date'] ? sanitize_text_field( $_REQUEST['start_date'] ) : null;
+    $end_date   = isset( $_REQUEST['end_date'] ) && $_REQUEST['end_date'] ? sanitize_text_field( $_REQUEST['end_date'] ) : null;
 
     $args = [
         'post_type'      => 'project_task',

--- a/reports.php
+++ b/reports.php
@@ -1,325 +1,399 @@
 <?php
+/**
+ * ------------------------------------------------------------------
+ * 10.0 ADMIN PAGES & LINKS  (Reports)
+ * ------------------------------------------------------------------
+ *
+ * This file registers the **Reports** sub‑page that appears under the
+ * Tasks CPT and renders all report‑related markup/logic.
+ *
+ * CHANGELOG (excerpt)
+ * ------------------------------------------------------------------
+ * 1.6.6 – 2025‑07‑20
+ *   • Fixed: Manual time entries (manual_override = 1) were excluded
+ *     from reports because they do not always have a stop_time.
+ *   • Improved: When a task has no start_time (e.g. imported manual
+ *     entries) we now fall back to the post’s publish date so the
+ *     report never shows “1970‑01‑01”.
+ * ------------------------------------------------------------------
+ */
 
-// If this file is called directly, abort.
+// Block direct access.
 if ( ! defined( 'WPINC' ) ) {
-    die;
+	die;
 }
 
-// =================================================================
-// 10.0 ADMIN PAGES & LINKS
-// =================================================================
-
-/**
- * Helper function to process and format task notes for display in reports.
- * 
- * @param string $content The post content to process.
- * @param int $max_length Maximum length before truncation (default: 200).
- * @return string Formatted content with URLs converted to links and truncation.
- */
+/*===================================================================
+ * Helper: Format Task Notes (URLs → links, truncate > 200 chars)
+ *==================================================================*/
 function ptt_format_task_notes( $content, $max_length = 200 ) {
-    // Strip all HTML tags first
-    $content = wp_strip_all_tags( $content );
-    
-    // Trim whitespace
-    $content = trim( $content );
-    
-    if ( empty( $content ) ) {
-        return '';
-    }
-    
-    // First, truncate if needed
-    $truncated = false;
-    if ( strlen( $content ) > $max_length ) {
-        $content = substr( $content, 0, $max_length - 3 );
-        $truncated = true;
-    }
-    
-    // Escape HTML entities
-    $content = esc_html( $content );
-    
-    // Pattern to match URLs anywhere in the text
-    // This pattern matches http://, https://, and common URL formats
-    $url_pattern = '/(https?:\/\/[^\s<>"{}|\\^`\[\]]+)/i';
-    
-    // Replace URLs with clickable links
-    $formatted_content = preg_replace_callback( $url_pattern, function( $matches ) {
-        $url = $matches[1];
-        // For display, truncate very long URLs in the link text
-        $display_url = strlen( $url ) > 50 ? substr( $url, 0, 47 ) . '...' : $url;
-        return '<a href="' . esc_url( $url ) . '" target="_blank" rel="noopener noreferrer">' . $display_url . '</a>';
-    }, $content );
-    
-    // Add ellipses if content was truncated
-    if ( $truncated ) {
-        $formatted_content .= '...';
-    }
-    
-    return $formatted_content;
+	$content = wp_strip_all_tags( $content );
+	$content = trim( $content );
+
+	if ( empty( $content ) ) {
+		return '';
+	}
+
+	$truncated = false;
+	if ( strlen( $content ) > $max_length ) {
+		$content  = substr( $content, 0, $max_length - 3 );
+		$truncated = true;
+	}
+
+	$content = esc_html( $content );
+
+	$url_pattern = '/(https?:\/\/[^\s<>"{}|\\^`\[\]]+)/i';
+	$content     = preg_replace_callback(
+		$url_pattern,
+		function ( $m ) {
+			$url         = $m[1];
+			$display_url = strlen( $url ) > 50 ? substr( $url, 0, 47 ) . '…' : $url;
+			return '<a href="' . esc_url( $url ) . '" target="_blank" rel="noopener noreferrer">' . $display_url . '</a>';
+		},
+		$content
+	);
+
+	if ( $truncated ) {
+		$content .= '…';
+	}
+
+	return $content;
 }
 
-/**
- * Adds the "Reports" page under the "Tasks" menu.
- */
+/*===================================================================
+ * Register admin‑side “Reports” sub‑menu
+ *==================================================================*/
 function ptt_add_reports_page() {
-    add_submenu_page(
-        'edit.php?post_type=project_task', // Parent slug
-        'Time Reports',                    // Page title
-        'Reports',                         // Menu title
-        'manage_options',                  // Capability
-        'ptt-reports',                     // Menu slug
-        'ptt_reports_page_html'            // Function
-    );
+	add_submenu_page(
+		'edit.php?post_type=project_task',
+		'Time Reports',
+		'Reports',
+		'manage_options',
+		'ptt-reports',
+		'ptt_reports_page_html'
+	);
 }
 add_action( 'admin_menu', 'ptt_add_reports_page' );
 
-/**
- * Renders the HTML for the reports page.
- */
+/*===================================================================
+ * Reports page HTML (filter form + results container)
+ *==================================================================*/
 function ptt_reports_page_html() {
-    ?>
-    <div class="wrap">
-        <h1>Project & Task Time Reports</h1>
-        
-        <form method="get" action="">
-            <?php wp_nonce_field( 'ptt_run_report_nonce' ); ?>
-            <input type="hidden" name="post_type" value="project_task" />
-            <input type="hidden" name="page" value="ptt-reports" />
-            <table class="form-table">
-                <tbody>
-                    <tr>
-                        <th scope="row"><label for="user_id">Select User</label></th>
-                        <td>
-                            <?php wp_dropdown_users( [
-                                'name' => 'user_id',
-                                'show_option_all' => 'All Users',
-                                'selected' => isset($_REQUEST['user_id']) ? intval($_REQUEST['user_id']) : 0
-                            ] ); ?>
-                        </td>
-                    </tr>
-                     <tr>
-                        <th scope="row"><label for="client_id">Select Client</label></th>
-                        <td>
-                            <?php wp_dropdown_categories( [
-                                'taxonomy'        => 'client',
-                                'name'            => 'client_id',
-                                'show_option_all' => 'All Clients',
-                                'hide_empty'      => false,
-                                'selected'        => isset($_REQUEST['client_id']) ? intval($_REQUEST['client_id']) : 0,
-                                'hierarchical'    => true,
-                                'class'           => '' // Reset class to avoid conflict
-                            ] ); ?>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><label for="project_id">Select Project</label></th>
-                        <td>
-                             <?php wp_dropdown_categories( [
-                                'taxonomy'        => 'project',
-                                'name'            => 'project_id',
-                                'show_option_all' => 'All Projects',
-                                'hide_empty'      => false,
-                                'selected'        => isset($_REQUEST['project_id']) ? intval($_REQUEST['project_id']) : 0,
-                                'hierarchical'    => true,
-                                'class'           => '' // Reset class to avoid conflict
-                            ] ); ?>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row"><label for="start_date">Date Range</label></th>
-                        <td>
-                            <input type="date" id="start_date" name="start_date" value="<?php echo isset($_REQUEST['start_date']) ? esc_attr($_REQUEST['start_date']) : ''; ?>">
-                            to
-                            <input type="date" id="end_date" name="end_date" value="<?php echo isset($_REQUEST['end_date']) ? esc_attr($_REQUEST['end_date']) : ''; ?>">
-                             <button type="button" id="set-this-week" class="button">This Week (Sun-Sat)</button>
-                             <button type="button" id="set-last-week" class="button">Last Week</button>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-            <p class="submit">
-                <input type="submit" name="run_report" class="button button-primary" value="Run Report">
-            </p>
-        </form>
+	?>
+	<div class="wrap">
+		<h1>Project &amp; Task Time Reports</h1>
 
-        <?php
-        if ( isset( $_REQUEST['run_report'] ) ) {
-            check_admin_referer( 'ptt_run_report_nonce' );
-            ptt_display_report_results();
-        }
-        ?>
-    </div>
-    <?php
+		<form method="get" action="">
+			<?php wp_nonce_field( 'ptt_run_report_nonce' ); ?>
+			<input type="hidden" name="post_type" value="project_task">
+			<input type="hidden" name="page"      value="ptt-reports">
+
+			<table class="form-table">
+				<tbody>
+					<tr>
+						<th scope="row"><label for="user_id">Select User</label></th>
+						<td>
+							<?php
+							wp_dropdown_users( [
+								'name'            => 'user_id',
+								'show_option_all' => 'All Users',
+								'selected'        => isset( $_REQUEST['user_id'] ) ? intval( $_REQUEST['user_id'] ) : 0,
+							] );
+							?>
+						</td>
+					</tr>
+
+					<tr>
+						<th scope="row"><label for="client_id">Select Client</label></th>
+						<td>
+							<?php
+							wp_dropdown_categories( [
+								'taxonomy'        => 'client',
+								'name'            => 'client_id',
+								'show_option_all' => 'All Clients',
+								'hide_empty'      => false,
+								'selected'        => isset( $_REQUEST['client_id'] ) ? intval( $_REQUEST['client_id'] ) : 0,
+								'hierarchical'    => true,
+								'class'           => '',
+							] );
+							?>
+						</td>
+					</tr>
+
+					<tr>
+						<th scope="row"><label for="project_id">Select Project</label></th>
+						<td>
+							<?php
+							wp_dropdown_categories( [
+								'taxonomy'        => 'project',
+								'name'            => 'project_id',
+								'show_option_all' => 'All Projects',
+								'hide_empty'      => false,
+								'selected'        => isset( $_REQUEST['project_id'] ) ? intval( $_REQUEST['project_id'] ) : 0,
+								'hierarchical'    => true,
+								'class'           => '',
+							] );
+							?>
+						</td>
+					</tr>
+
+					<tr>
+						<th scope="row"><label for="start_date">Date Range</label></th>
+						<td>
+							<input type="date" id="start_date" name="start_date"
+								   value="<?php echo isset( $_REQUEST['start_date'] ) ? esc_attr( $_REQUEST['start_date'] ) : ''; ?>">
+							to
+							<input type="date" id="end_date" name="end_date"
+								   value="<?php echo isset( $_REQUEST['end_date'] ) ? esc_attr( $_REQUEST['end_date'] ) : ''; ?>">
+
+							<button type="button" id="set-this-week" class="button">This Week (Sun‑Sat)</button>
+							<button type="button" id="set-last-week" class="button">Last Week</button>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<p class="submit">
+				<input type="submit" name="run_report" class="button button-primary" value="Run Report">
+			</p>
+		</form>
+
+		<?php
+		if ( isset( $_REQUEST['run_report'] ) ) {
+			check_admin_referer( 'ptt_run_report_nonce' );
+			ptt_display_report_results();
+		}
+		?>
+	</div>
+	<?php
 }
 
-/**
- * Queries and displays the report results.
- */
+/*===================================================================
+ * Core: Query & Display report results
+ *==================================================================*/
 function ptt_display_report_results() {
-    $user_id    = isset( $_REQUEST['user_id'] ) ? intval( $_REQUEST['user_id'] ) : 0;
-    $client_id  = isset( $_REQUEST['client_id'] ) ? intval( $_REQUEST['client_id'] ) : 0;
-    $project_id = isset( $_REQUEST['project_id'] ) ? intval( $_REQUEST['project_id'] ) : 0;
-    $start_date = isset( $_REQUEST['start_date'] ) && $_REQUEST['start_date'] ? sanitize_text_field( $_REQUEST['start_date'] ) : null;
-    $end_date   = isset( $_REQUEST['end_date'] ) && $_REQUEST['end_date'] ? sanitize_text_field( $_REQUEST['end_date'] ) : null;
 
-    $args = [
-        'post_type'      => 'project_task',
-        'posts_per_page' => -1,
-        'post_status'    => 'publish',
-        'orderby'        => 'author',
-        'order'          => 'ASC',
-        'meta_query'     => [
-            'relation' => 'AND',
-            [ // Only include tasks that have been completed
-                'key'     => 'stop_time',
-                'compare' => 'EXISTS'
-            ],
-            [
-                'key'     => 'stop_time',
-                'value'   => '',
-                'compare' => '!='
-            ]
-        ]
-    ];
-    
-    if ( $user_id ) {
-        $args['author'] = $user_id;
-    }
+	$user_id    = isset( $_REQUEST['user_id'] )    ? intval( $_REQUEST['user_id'] )    : 0;
+	$client_id  = isset( $_REQUEST['client_id'] )  ? intval( $_REQUEST['client_id'] )  : 0;
+	$project_id = isset( $_REQUEST['project_id'] ) ? intval( $_REQUEST['project_id'] ) : 0;
+	$start_date = ! empty( $_REQUEST['start_date'] ) ? sanitize_text_field( $_REQUEST['start_date'] ) : null;
+	$end_date   = ! empty( $_REQUEST['end_date'] )   ? sanitize_text_field( $_REQUEST['end_date'] )   : null;
 
-    // Add taxonomy query
-    $tax_query = ['relation' => 'AND'];
-    if ( $client_id > 0 ) {
-        $tax_query[] = [
-            'taxonomy' => 'client',
-            'field'    => 'term_id',
-            'terms'    => $client_id,
-        ];
-    }
-    if ( $project_id > 0 ) {
-        $tax_query[] = [
-            'taxonomy' => 'project',
-            'field'    => 'term_id',
-            'terms'    => $project_id,
-        ];
-    }
-    if ( count( $tax_query ) > 1 ) {
-        $args['tax_query'] = $tax_query;
-    }
+	/*--------------------------------------------------------------
+	 * Build WP_Query arguments
+	 *-------------------------------------------------------------*/
+	$args = [
+		'post_type'      => 'project_task',
+		'posts_per_page' => -1,
+		'post_status'    => 'publish',
+		'orderby'        => 'author',
+		'order'          => 'ASC',
+		'meta_query'     => [
+			'relation' => 'AND',
 
-    if ( $start_date && $end_date ) {
-        $args['meta_query'][] = [
-            'key'     => 'start_time',
-            'value'   => [ $start_date . ' 00:00:00', $end_date . ' 23:59:59' ],
-            'compare' => 'BETWEEN',
-            'type'    => 'DATETIME'
-        ];
-    }
+			/*----------------------------------------------
+			 * ❶ Completed OR Manual‑only tasks
+			 *---------------------------------------------*/
+			[
+				'relation' => 'OR',
 
-    $query = new WP_Query( $args );
+				// Timer‑based tasks must have a non‑empty stop_time.
+				[
+					'relation' => 'AND',
+					[
+						'key'     => 'stop_time',
+						'compare' => 'EXISTS',
+					],
+					[
+						'key'     => 'stop_time',
+						'value'   => '',
+						'compare' => '!=',
+					],
+				],
 
-    if ( ! $query->have_posts() ) {
-        echo '<p>No completed tasks found for the selected criteria.</p>';
-        return;
-    }
+				// Manual entries are flagged with manual_override = 1.
+				[
+					'key'     => 'manual_override',
+					'value'   => '1',
+					'compare' => '=',
+				],
+			],
+		],
+	];
 
-    // Process and group results
-    $report_data = [];
-    $grand_total = 0.00;
+	if ( $user_id ) {
+		$args['author'] = $user_id;
+	}
 
-    while ( $query->have_posts() ) {
-        $query->the_post();
-        $post_id      = get_the_ID();
-        $author_id    = get_the_author_meta('ID');
-        $author_name  = get_the_author_meta('display_name');
+	/* Taxonomy filtering */
+	$tax_query = [ 'relation' => 'AND' ];
+	if ( $client_id ) {
+		$tax_query[] = [
+			'taxonomy' => 'client',
+			'field'    => 'term_id',
+			'terms'    => $client_id,
+		];
+	}
+	if ( $project_id ) {
+		$tax_query[] = [
+			'taxonomy' => 'project',
+			'field'    => 'term_id',
+			'terms'    => $project_id,
+		];
+	}
+	if ( count( $tax_query ) > 1 ) {
+		$args['tax_query'] = $tax_query;
+	}
 
-        $clients      = get_the_terms($post_id, 'client');
-        $client_name  = !is_wp_error($clients) && !empty($clients) ? $clients[0]->name : 'Uncategorized';
-        $client_id_term = !is_wp_error($clients) && !empty($clients) ? $clients[0]->term_id : 0;
-        
-        $projects     = get_the_terms($post_id, 'project');
-        $project_name = !is_wp_error($projects) && !empty($projects) ? $projects[0]->name : 'Uncategorized';
-        $project_id_term = !is_wp_error($projects) && !empty($projects) ? $projects[0]->term_id : 0;
-        
-        $duration = (float) get_field('calculated_duration', $post_id);
-        
-        // Get task budget
-        $task_budget = get_field('task_max_budget', $post_id);
-        
-        // Get project budget (from taxonomy)
-        $project_budget = 0;
-        if ($project_id_term) {
-            $project_budget = get_field('project_max_budget', 'project_' . $project_id_term);
-        }
-        
-        if (!isset($report_data[$author_id])) {
-            $report_data[$author_id] = ['name' => $author_name, 'clients' => [], 'total' => 0];
-        }
+	/* Date‑range filtering (start_time) */
+	if ( $start_date && $end_date ) {
+		$args['meta_query'][] = [
+			'key'     => 'start_time',
+			'value'   => [ $start_date . ' 00:00:00', $end_date . ' 23:59:59' ],
+			'compare' => 'BETWEEN',
+			'type'    => 'DATETIME',
+		];
+	}
 
-        if (!isset($report_data[$author_id]['clients'][$client_id_term])) {
-            $report_data[$author_id]['clients'][$client_id_term] = ['name' => $client_name, 'projects' => [], 'total' => 0];
-        }
+	/*--------------------------------------------------------------
+	 * Execute query
+	 *-------------------------------------------------------------*/
+	$q = new WP_Query( $args );
 
-        if (!isset($report_data[$author_id]['clients'][$client_id_term]['projects'][$project_id_term])) {
-            $report_data[$author_id]['clients'][$client_id_term]['projects'][$project_id_term] = ['name' => $project_name, 'tasks' => [], 'total' => 0];
-        }
-        
-        $grand_total += $duration;
-        $report_data[$author_id]['total'] += $duration;
-        $report_data[$author_id]['clients'][$client_id_term]['total'] += $duration;
-        $report_data[$author_id]['clients'][$client_id_term]['projects'][$project_id_term]['total'] += $duration;
-        $report_data[$author_id]['clients'][$client_id_term]['projects'][$project_id_term]['tasks'][] = [
-            'id'       => $post_id,
-            'title'    => get_the_title(),
-            'date'     => get_field('start_time', $post_id),
-            'duration' => $duration,
-            'content'  => get_the_content(),
-            'task_budget' => $task_budget,
-            'project_budget' => $project_budget
-        ];
-    }
-    wp_reset_postdata();
+	if ( ! $q->have_posts() ) {
+		echo '<p>No matching tasks found for the selected criteria.</p>';
+		return;
+	}
 
-    // Display results
-    echo '<h2>Report Results</h2>';
-    echo '<div class="ptt-report-results">';
-    
-    foreach ($report_data as $author) {
-        echo '<h3>User: ' . esc_html($author['name']) . ' <span class="subtotal">(User Total: ' . number_format($author['total'], 2) . ' hrs)</span></h3>';
-       
-        foreach ($author['clients'] as $client) {
-            echo '<div class="client-group">';
-            echo '<h4>Client: ' . esc_html($client['name']) . ' <span class="subtotal">(Client Total: ' . number_format($client['total'], 2) . ' hrs)</span></h4>';
-            foreach ($client['projects'] as $project) {
-                echo '<div class="project-group">';
-                echo '<h5>Project: ' . esc_html($project['name']) . ' <span class="subtotal">(Project Total: ' . number_format($project['total'], 2) . ' hrs)</span></h5>';
-                echo '<table class="wp-list-table widefat fixed striped">';
-                echo '<thead><tr><th>Task Name</th><th>Date</th><th>Duration (Hours)</th><th>Orig. Budget</th><th>Notes</th></tr></thead>';
-                echo '<tbody>';
-                foreach ($project['tasks'] as $task) {
-                    // Format budget display
-                    $budget_display = '';
-                    if (!empty($task['task_budget']) && $task['task_budget'] > 0) {
-                        $budget_display = number_format((float)$task['task_budget'], 2) . ' (Task)';
-                    } elseif (!empty($task['project_budget']) && $task['project_budget'] > 0) {
-                        $budget_display = number_format((float)$task['project_budget'], 2) . ' (Project)';
-                    } else {
-                        $budget_display = '-';
-                    }
-                    
-                    echo '<tr>';
-                    echo '<td><a href="' . get_edit_post_link($task['id']) . '">' . esc_html($task['title']) . '</a></td>';
-                    echo '<td>' . esc_html(date('Y-m-d', strtotime($task['date']))) . '</td>';
-                    echo '<td>' . number_format($task['duration'], 2) . '</td>';
-                    echo '<td>' . $budget_display . '</td>';
-                    echo '<td>' . ptt_format_task_notes($task['content']) . '</td>';
-                    echo '</tr>';
-                }
-                echo '</tbody></table>';
-                echo '</div>'; // .project-group
-            }
-             echo '</div>'; // .client-group
-        }
-    }
-    
-    echo '<div class="grand-total"><strong>Grand Total: ' . number_format($grand_total, 2) . ' hours</strong></div>';
-    echo '</div>'; // .ptt-report-results
+	/*--------------------------------------------------------------
+	 * Transform into hierarchical array → User > Client > Project
+	 *-------------------------------------------------------------*/
+	$report   = [];
+	$grand_total = 0.0;
+
+	while ( $q->have_posts() ) {
+		$q->the_post();
+		$post_id = get_the_ID();
+
+		// -------- Meta & taxonomy look‑ups --------
+		$author_id   = get_the_author_meta( 'ID' );
+		$author_name = get_the_author_meta( 'display_name' );
+
+		$client_terms = get_the_terms( $post_id, 'client' );
+		$client_id_term = ! is_wp_error( $client_terms ) && $client_terms ? $client_terms[0]->term_id : 0;
+		$client_name    = ! is_wp_error( $client_terms ) && $client_terms ? $client_terms[0]->name     : 'Uncategorized';
+
+		$project_terms = get_the_terms( $post_id, 'project' );
+		$project_id_term = ! is_wp_error( $project_terms ) && $project_terms ? $project_terms[0]->term_id : 0;
+		$project_name    = ! is_wp_error( $project_terms ) && $project_terms ? $project_terms[0]->name     : 'Uncategorized';
+
+		// -------- Duration / Budget --------
+		$duration       = (float) get_field( 'calculated_duration', $post_id );
+		$task_budget    = get_field( 'task_max_budget', $post_id );
+		$project_budget = $project_id_term ? get_field( 'project_max_budget', 'project_' . $project_id_term ) : 0;
+
+		// -------- Start date (fallback) --------
+		$start_time = get_field( 'start_time', $post_id );
+		if ( ! $start_time ) {
+			$start_time = get_the_date( 'Y-m-d H:i:s', $post_id );
+		}
+
+		// -------- Build array --------
+		if ( ! isset( $report[ $author_id ] ) ) {
+			$report[ $author_id ] = [
+				'name'    => $author_name,
+				'total'   => 0,
+				'clients' => [],
+			];
+		}
+		if ( ! isset( $report[ $author_id ]['clients'][ $client_id_term ] ) ) {
+			$report[ $author_id ]['clients'][ $client_id_term ] = [
+				'name'     => $client_name,
+				'total'    => 0,
+				'projects' => [],
+			];
+		}
+		if ( ! isset( $report[ $author_id ]['clients'][ $client_id_term ]['projects'][ $project_id_term ] ) ) {
+			$report[ $author_id ]['clients'][ $client_id_term ]['projects'][ $project_id_term ] = [
+				'name'  => $project_name,
+				'total' => 0,
+				'tasks' => [],
+			];
+		}
+
+		$report[ $author_id ]['total']                                       += $duration;
+		$report[ $author_id ]['clients'][ $client_id_term ]['total']         += $duration;
+		$report[ $author_id ]['clients'][ $client_id_term ]['projects'][ $project_id_term ]['total'] += $duration;
+		$report[ $author_id ]['clients'][ $client_id_term ]['projects'][ $project_id_term ]['tasks'][] = [
+			'id'             => $post_id,
+			'title'          => get_the_title(),
+			'date'           => $start_time,
+			'duration'       => $duration,
+			'content'        => get_the_content(),
+			'task_budget'    => $task_budget,
+			'project_budget' => $project_budget,
+		];
+
+		$grand_total += $duration;
+	}
+	wp_reset_postdata();
+
+	/*--------------------------------------------------------------
+	 * Render HTML
+	 *-------------------------------------------------------------*/
+	echo '<h2>Report Results</h2><div class="ptt-report-results">';
+
+	foreach ( $report as $author ) {
+
+		echo '<h3>User: ' . esc_html( $author['name'] ) .
+		     ' <span class="subtotal">(User&nbsp;Total: ' . number_format( $author['total'], 2 ) . '&nbsp;hrs)</span></h3>';
+
+		foreach ( $author['clients'] as $client ) {
+
+			echo '<div class="client-group">';
+			echo '<h4>Client: ' . esc_html( $client['name'] ) .
+			     ' <span class="subtotal">(Client&nbsp;Total: ' . number_format( $client['total'], 2 ) . '&nbsp;hrs)</span></h4>';
+
+			foreach ( $client['projects'] as $project ) {
+
+				echo '<div class="project-group">';
+				echo '<h5>Project: ' . esc_html( $project['name'] ) .
+				     ' <span class="subtotal">(Project&nbsp;Total: ' . number_format( $project['total'], 2 ) . '&nbsp;hrs)</span></h5>';
+
+				echo '<table class="wp-list-table widefat fixed striped">';
+				echo '<thead><tr>
+						<th>Task Name</th><th>Date</th><th>Duration (Hours)</th>
+						<th>Orig.&nbsp;Budget</th><th>Notes</th>
+					  </tr></thead><tbody>';
+
+				foreach ( $project['tasks'] as $task ) {
+
+					// Budget column display
+					if ( ! empty( $task['task_budget'] ) && $task['task_budget'] > 0 ) {
+						$budget_display = number_format( (float) $task['task_budget'], 2 ) . '&nbsp;(Task)';
+					} elseif ( ! empty( $task['project_budget'] ) && $task['project_budget'] > 0 ) {
+						$budget_display = number_format( (float) $task['project_budget'], 2 ) . '&nbsp;(Project)';
+					} else {
+						$budget_display = '–';
+					}
+
+					echo '<tr>';
+					echo '<td><a href="' . get_edit_post_link( $task['id'] ) . '">' . esc_html( $task['title'] ) . '</a></td>';
+					echo '<td>' . esc_html( date( 'Y-m-d', strtotime( $task['date'] ) ) ) . '</td>';
+					echo '<td>' . number_format( $task['duration'], 2 ) . '</td>';
+					echo '<td>' . $budget_display . '</td>';
+					echo '<td>' . ptt_format_task_notes( $task['content'] ) . '</td>';
+					echo '</tr>';
+				}
+
+				echo '</tbody></table></div>'; // .project-group
+			}
+
+			echo '</div>'; // .client-group
+		}
+	}
+
+	echo '<div class="grand-total"><strong>Grand Total: ' .
+	     number_format( $grand_total, 2 ) . '&nbsp;hours</strong></div>';
+	echo '</div>'; // .ptt-report-results
 }

--- a/scripts.js
+++ b/scripts.js
@@ -180,6 +180,114 @@ jQuery(document).ready(function ($) {
         });
     }
 
+    function initSessionRows($context) {
+        $context = $context || $(document);
+        $context.find('.ptt-session-timer').each(function() {
+            const $container = $(this);
+            if ($container.data('initialized')) return;
+            $container.data('initialized', true);
+
+            const $row = $container.closest('.acf-row');
+            const $startInput = $row.find('[data-key="field_ptt_session_start_time"] input');
+            const $stopInput = $row.find('[data-key="field_ptt_session_stop_time"] input');
+
+            const controlsHtml = '<div class="ptt-session-controls">' +
+                '<button type="button" class="button ptt-session-start">Start Session</button>' +
+                '<button type="button" class="button ptt-session-stop">Stop Session</button>' +
+                '<div class="ptt-ajax-spinner"></div><div class="ptt-ajax-message"></div>' +
+            '</div>';
+            $container.find('.acf-input > p').html(controlsHtml);
+
+            function updateButtons() {
+                const startVal = $startInput.val();
+                const stopVal = $stopInput.val();
+                if (!startVal) {
+                    $container.find('.ptt-session-start').show();
+                    $container.find('.ptt-session-stop').hide();
+                } else if (startVal && !stopVal) {
+                    $container.find('.ptt-session-start').hide();
+                    $container.find('.ptt-session-stop').show();
+                } else {
+                    $container.find('.ptt-session-start').hide();
+                    $container.find('.ptt-session-stop').hide();
+                }
+            }
+
+            updateButtons();
+            $startInput.on('change', updateButtons);
+            $stopInput.on('change', updateButtons);
+        });
+    }
+
+    initSessionRows();
+    if (window.acf) {
+        window.acf.addAction('append', function($el){
+            initSessionRows($el);
+        });
+    }
+
+    $(document).on('click', '.ptt-session-start', function(e){
+        e.preventDefault();
+        const $btn = $(this);
+        const $row = $btn.closest('.acf-row');
+        const index = $row.index();
+        const postId = $('#post_ID').val();
+        const $container = $btn.closest('.ptt-session-controls');
+        $btn.prop('disabled', true);
+        showSpinner($container);
+
+        $.post(ptt_ajax_object.ajax_url, {
+            action: 'ptt_start_session_timer',
+            nonce: ptt_ajax_object.nonce,
+            post_id: postId,
+            row_index: index
+        }).done(function(response){
+            if(response.success){
+                showMessage($container, response.data.message, false);
+                setTimeout(function(){ window.location.reload(); }, 1000);
+            } else {
+                showMessage($container, response.data.message, true);
+                $btn.prop('disabled', false);
+            }
+        }).fail(function(){
+            showMessage($container, 'An unexpected error occurred.', true);
+            $btn.prop('disabled', false);
+        }).always(function(){
+            hideSpinner($container);
+        });
+    });
+
+    $(document).on('click', '.ptt-session-stop', function(e){
+        e.preventDefault();
+        const $btn = $(this);
+        const $row = $btn.closest('.acf-row');
+        const index = $row.index();
+        const postId = $('#post_ID').val();
+        const $container = $btn.closest('.ptt-session-controls');
+        $btn.prop('disabled', true);
+        showSpinner($container);
+
+        $.post(ptt_ajax_object.ajax_url, {
+            action: 'ptt_stop_session_timer',
+            nonce: ptt_ajax_object.nonce,
+            post_id: postId,
+            row_index: index
+        }).done(function(response){
+            if(response.success){
+                showMessage($container, response.data.message, false);
+                setTimeout(function(){ window.location.reload(); }, 1000);
+            } else {
+                showMessage($container, response.data.message, true);
+                $btn.prop('disabled', false);
+            }
+        }).fail(function(){
+            showMessage($container, 'An unexpected error occurred.', true);
+            $btn.prop('disabled', false);
+        }).always(function(){
+            hideSpinner($container);
+        });
+    });
+
 
     /**
      * ---------------------------------------------------------------

--- a/scripts.js
+++ b/scripts.js
@@ -105,6 +105,34 @@ function validateSessionRows() {
      * ADMIN UI (CPT EDITOR)
      * ---------------------------------------------------------------
      */
+
+    // Add "Use Today's Date" button next to the title input
+    if ($('body').hasClass('post-type-project_task') && ($('body').hasClass('post-new-php') || $('body').hasClass('post-php'))) {
+        const $titlewrap = $('#titlewrap');
+        if ($titlewrap.length) {
+            const dateButton = $('<button type="button" id="ptt-use-todays-date" class="button" style="margin-bottom: 10px;">Use Today\'s Date</button>');
+            $titlewrap.after(dateButton); // Place button after the title wrapper
+
+            dateButton.on('click', function(e) {
+                e.preventDefault();
+                const today = ptt_ajax_object.todays_date_formatted;
+                const $titleInput = $('#title');
+                const currentTitle = $titleInput.val();
+                let newTitle = today + ' - ' + currentTitle;
+                
+                if ( !currentTitle.trim() ) {
+                    newTitle = today + ' - ';
+                } else if (currentTitle.includes(today)) {
+                    // Don't add if date is already there
+                    return; 
+                }
+                
+                $titleInput.val(newTitle);
+                $('#title-prompt-text').addClass('screen-reader-text');
+            });
+        }
+    }
+    
     if ($('#ptt-timer-controls').length) {
         const $timerControls = $('#ptt-timer-controls');
         const postId = $timerControls.data('postid');

--- a/scripts.js
+++ b/scripts.js
@@ -56,13 +56,48 @@ jQuery(document).ready(function ($) {
             .fadeOut('slow');
     }
 
-    function showMessageWithHTML($container, html, isError) {
-        $container.find('.ptt-ajax-message')
-            .html(html)
-            .removeClass('success error')
-            .addClass(isError ? 'error' : 'success')
-            .show();
-    }
+function showMessageWithHTML($container, html, isError) {
+    $container.find('.ptt-ajax-message')
+        .html(html)
+        .removeClass('success error')
+        .addClass(isError ? 'error' : 'success')
+        .show();
+}
+
+function validateSessionRows() {
+    let valid = true;
+    $('.acf-field[data-key="field_ptt_sessions"] .acf-row').each(function(){
+        const $row = $(this);
+        const title = $row.find('[data-key="field_ptt_session_title"] input').val();
+        const notes = $row.find('[data-key="field_ptt_session_notes"] textarea').val();
+        const start = $row.find('[data-key="field_ptt_session_start_time"] input').val();
+        const stop = $row.find('[data-key="field_ptt_session_stop_time"] input').val();
+        const override = $row.find('[data-key="field_ptt_session_manual_override"] input').prop('checked');
+        const manual = $row.find('[data-key="field_ptt_session_manual_duration"] input').val();
+
+        if (!title || !notes) {
+            valid = false;
+            return false;
+        }
+
+        if (override) {
+            if (manual === '' || manual === null) {
+                valid = false;
+                return false;
+            }
+        } else {
+            if (!start || !stop) {
+                valid = false;
+                return false;
+            }
+            if (start && !stop) {
+                valid = false;
+                return false;
+            }
+        }
+    });
+    return valid;
+}
 
 
     /**
@@ -225,6 +260,18 @@ jQuery(document).ready(function ($) {
             initSessionRows($el);
         });
     }
+
+    $(document).on('click', '.acf-field[data-key="field_ptt_sessions"] [data-event="add-row"], .acf-field[data-key="field_ptt_sessions"] [data-name="add-row"]', function(e){
+        if (!validateSessionRows()) {
+            e.preventDefault();
+            alert('Please complete all session fields and stop running timers before adding another session.');
+            return false;
+        }
+        const $btn = $('#publish');
+        if ($btn.length) {
+            setTimeout(function(){ $btn.trigger('click'); }, 100);
+        }
+    });
 
     $(document).on('click', '.ptt-session-start', function(e){
         e.preventDefault();

--- a/scripts.js
+++ b/scripts.js
@@ -195,6 +195,7 @@ jQuery(document).ready(function ($) {
         const $createNewFields = $('#ptt-create-new-fields');
         const $projectBudgetDisplay = $('#ptt-project-budget-display');
         const $taskBudgetDisplay = $('#ptt-task-budget-display');
+        const $taskStatusDisplay = $('#ptt-task-status-display');
         const $messageContainer = $('#ptt-frontend-message').parent();
         let suggestedTimeInterval = null;
         let activeTimerInterval = null;
@@ -213,6 +214,7 @@ jQuery(document).ready(function ($) {
             }).done(function(response) {
                 if (response.success) {
                     $('#ptt-active-task-name').text(response.data.task_name);
+                    $('#ptt-active-task-status').text(response.data.task_status || '');
                     $('#ptt-frontend-stop-btn').data('postid', response.data.post_id);
                     $('#ptt-frontend-force-stop-btn').data('postid', response.data.post_id);
                     $newTaskForm.hide();
@@ -225,6 +227,7 @@ jQuery(document).ready(function ($) {
                     // Try to verify if it's still valid
                     showMessage($messageContainer, 'Recovering previous session...', false);
                     $('#ptt-active-task-name').text(storedTask.taskName + ' (Recovering...)');
+                    $('#ptt-active-task-status').text('');
                     $('#ptt-frontend-stop-btn').data('postid', storedTask.postId);
                     $('#ptt-frontend-force-stop-btn').data('postid', storedTask.postId);
                     $newTaskForm.hide();
@@ -240,6 +243,7 @@ jQuery(document).ready(function ($) {
                 if (storedTask && storedTask.postId) {
                     showMessage($messageContainer, 'Connection error. Showing cached task data.', true);
                     $('#ptt-active-task-name').text(storedTask.taskName + ' (Offline)');
+                    $('#ptt-active-task-status').text('');
                     $('#ptt-frontend-stop-btn').data('postid', storedTask.postId);
                     $('#ptt-frontend-force-stop-btn').data('postid', storedTask.postId);
                     $newTaskForm.hide();
@@ -323,6 +327,7 @@ jQuery(document).ready(function ($) {
             $taskSelect.html('<option value="">Loading tasks...</option>').prop('disabled', true);
             $createNewFields.hide();
             $taskBudgetDisplay.hide().data('budget-hours', '');
+            $taskStatusDisplay.hide();
             $projectBudgetDisplay.hide();
 
             if (!projectId) {
@@ -377,10 +382,17 @@ jQuery(document).ready(function ($) {
                         nonce: ptt_ajax_object.nonce,
                         task_id: taskId
                     }).done(function(response) {
-                        if (response.success && response.data.task_budget && parseFloat(response.data.task_budget) > 0) {
-                            $taskBudgetDisplay.data('budget-hours', response.data.task_budget).show();
-                            updateSuggestedTime(); // Initial call
-                            suggestedTimeInterval = setInterval(updateSuggestedTime, 300000); // 5 minutes
+                        if (response.success) {
+                            if (response.data.task_budget && parseFloat(response.data.task_budget) > 0) {
+                                $taskBudgetDisplay.data('budget-hours', response.data.task_budget).show();
+                                updateSuggestedTime(); // Initial call
+                                suggestedTimeInterval = setInterval(updateSuggestedTime, 300000); // 5 minutes
+                            }
+                            if (response.data.task_status) {
+                                $taskStatusDisplay.text('Current Status: ' + response.data.task_status).show();
+                            } else {
+                                $taskStatusDisplay.hide();
+                            }
                         }
                     });
                 }
@@ -440,6 +452,7 @@ jQuery(document).ready(function ($) {
                         const currentTaskName = (selectedTaskId === 'new') ? formData.task_name : $taskSelect.find('option:selected').text();
                         const taskPostId = response.data.post_id || selectedTaskId;
                         $('#ptt-active-task-name').text(currentTaskName);
+                        $('#ptt-active-task-status').text(response.data.task_status || '');
                         $('#ptt-frontend-stop-btn').data('postid', taskPostId);
                         $('#ptt-frontend-force-stop-btn').data('postid', taskPostId);
                         $newTaskForm.hide();
@@ -526,6 +539,7 @@ jQuery(document).ready(function ($) {
                     $taskSelect.html('<option value="">-- Select Project First --</option>').prop('disabled', true);
                     $createNewFields.hide();
                     $taskBudgetDisplay.hide().data('budget-hours', '');
+                    $taskStatusDisplay.hide();
                     $projectBudgetDisplay.hide();
                     $newTaskForm.show();
                     $('#ptt-frontend-start-btn').prop('disabled', false);
@@ -586,6 +600,7 @@ jQuery(document).ready(function ($) {
                     $taskSelect.html('<option value="">-- Select Project First --</option>').prop('disabled', true);
                     $createNewFields.hide();
                     $taskBudgetDisplay.hide().data('budget-hours', '');
+                    $taskStatusDisplay.hide();
                     $projectBudgetDisplay.hide();
                     $newTaskForm.show();
                     $('#ptt-frontend-start-btn').prop('disabled', false);

--- a/styles.css
+++ b/styles.css
@@ -24,7 +24,8 @@
     justify-content: center;
 }
 
-#ptt-active-task-timer .colon {
+#ptt-active-task-timer .colon,
+.ptt-session-elapsed-time .colon {
     animation: ptt-blink 1s step-end infinite;
 }
 
@@ -57,9 +58,41 @@
     color: #d94848;
 }
 
+/* --- Session Timer Styles --- */
 .ptt-session-controls {
     margin-top: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
+
+.ptt-session-active-timer {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.ptt-session-elapsed-time {
+    font-family: monospace;
+    font-size: 1.2em;
+    font-weight: bold;
+    color: #f44336; /* Red for running timer */
+    background: #fdf2f2;
+    padding: 2px 6px;
+    border-radius: 3px;
+    border: 1px solid #fde0e0;
+}
+
+.ptt-session-elapsed-time .colon {
+    position: relative;
+    top: -1px;
+}
+
+.ptt-session-message {
+    font-style: italic;
+    color: #555;
+}
+
 
 /* --- Frontend Shortcode Styles --- */
 .ptt-frontend-container {

--- a/styles.css
+++ b/styles.css
@@ -57,6 +57,10 @@
     color: #d94848;
 }
 
+.ptt-session-controls {
+    margin-top: 8px;
+}
+
 /* --- Frontend Shortcode Styles --- */
 .ptt-frontend-container {
     max-width: 600px;

--- a/styles.css
+++ b/styles.css
@@ -169,38 +169,44 @@
 
 .ptt-report-results table th:nth-child(2), /* Date */
 .ptt-report-results table td:nth-child(2) {
-    width: 12%;
+    width: 10%;
 }
 
 .ptt-report-results table th:nth-child(3), /* Duration */
 .ptt-report-results table td:nth-child(3) {
-    width: 12%;
+    width: 10%;
 }
 
 .ptt-report-results table th:nth-child(4), /* Orig. Budget */
 .ptt-report-results table td:nth-child(4) {
-    width: 15%;
+    width: 10%;
 }
 
 /* Notes column styling */
-.ptt-report-results table th:last-child,
-.ptt-report-results table td:last-child {
-    width: 31%;
+.ptt-report-results table th:nth-child(5),
+.ptt-report-results table td:nth-child(5) {
+    width: 30%;
 }
 
-.ptt-report-results table td:last-child {
+/* Status column styling */
+.ptt-report-results table th:nth-child(6),
+.ptt-report-results table td:nth-child(6) {
+    width: 10%;
+}
+
+.ptt-report-results table td:nth-child(5) {
     font-size: 13px;
     line-height: 1.4;
     color: #555;
 }
 
-.ptt-report-results table td:last-child a {
+.ptt-report-results table td:nth-child(5) a {
     color: #0073aa;
     text-decoration: none;
     word-break: break-all;
 }
 
-.ptt-report-results table td:last-child a:hover {
+.ptt-report-results table td:nth-child(5) a:hover {
     color: #00a0d2;
     text-decoration: underline;
 }

--- a/templates/single-project_task.php
+++ b/templates/single-project_task.php
@@ -1,0 +1,15 @@
+<?php
+get_header();
+
+if ( ! is_user_logged_in() || ! current_user_can( 'edit_posts' ) ) {
+    echo '<p>' . esc_html__( 'You do not have permission to view this task.', 'ptt' ) . '</p>';
+    get_footer();
+    return;
+}
+
+while ( have_posts() ) : the_post();
+    echo '<h1>' . esc_html( get_the_title() ) . '</h1>';
+    echo ptt_get_timer_controls_html( get_the_ID() );
+endwhile;
+
+get_footer();


### PR DESCRIPTION
### Version 1.7.4 (2025-07-21)
* **Docs:** Added detailed user instructions and an FAQ section to the Readme file.
* **Feature:** On screen debugger code for  timer in scripts.js - comment out later

### Version 1.7.3 (2025-07-21)
* **Feature:** Session rows in the admin editor now have a live, one-click timer.
* **Feature:** Starting and stopping a session timer no longer requires a page reload.
* **Improved:** Re-used front-end timer logic for back-end sessions to adhere to DRY principles.
* **Fixed:** Session validation now correctly checks for running timers before allowing a new session to be added.

### Version 1.7.2 (2025-07-21)
* **Feature:** Orig. Budget amount in reports now appears in red if the task duration exceeds the budget.
* **Feature:** Added a "Use Today's Date" button under the post title field on the Add/Edit Task screen to quickly prepend the current date.
