### PR TITLE
Expand self-test suite

### DIFF
--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.9
+ * Version:           1.7.10
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.9' );
+define( 'PTT_VERSION', '1.7.10' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.8
+ * Version:           1.7.9
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.8' );
+define( 'PTT_VERSION', '1.7.9' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,8 @@ A: The total time tracked for the task has exceeded the hours you set in the "Ma
 ***
 
 ## 📋 Changelog
+### Version 1.7.9 (2025-07-23)
+* **Dev:** Expanded self-test coverage for AJAX handlers, concurrent tasks, sessions, shortcodes and reports.
 ### Version 1.7.8 (2025-07-22)
 * **Feature:** The Status column on the Reports page is now an editable dropdown menu, allowing for instant, auto-saving updates to a task's status.
 

--- a/readme.md
+++ b/readme.md
@@ -123,8 +123,8 @@ A: The total time tracked for the task has exceeded the hours you set in the "Ma
 ***
 
 ## 📋 Changelog
-### Version 1.7.9 (2025-07-23)
-* **Dev:** Expanded self-test coverage for AJAX handlers, concurrent tasks, sessions, shortcodes and reports.
+### Version 1.7.10 (2025-07-23)
+* **Dev:** Refined self-test module to cover status updates and reporting logic.
 ### Version 1.7.8 (2025-07-22)
 * **Feature:** The Status column on the Reports page is now an editable dropdown menu, allowing for instant, auto-saving updates to a task's status.
 

--- a/reports.php
+++ b/reports.php
@@ -9,6 +9,9 @@
  *
  * CHANGELOG (excerpt)
  * ------------------------------------------------------------------
+ * 1.7.9 – 2025-07-23
+ * • Dev: Expanded self-tests with additional AJAX and reporting checks.
+ *
  * 1.7.8 – 2025-07-22
  * • Feature: Added an inline-editable dropdown to the Status column on the reports page, allowing for quick task status updates.
  * • Improved: The new status dropdown saves changes instantly via AJAX without a page reload.

--- a/reports.php
+++ b/reports.php
@@ -9,8 +9,8 @@
  *
  * CHANGELOG (excerpt)
  * ------------------------------------------------------------------
- * 1.7.9 – 2025-07-23
- * • Dev: Expanded self-tests with additional AJAX and reporting checks.
+ * 1.7.10 – 2025-07-23
+ * • Dev: Self tests now cover status update callbacks and reporting queries.
  *
  * 1.7.8 – 2025-07-22
  * • Feature: Added an inline-editable dropdown to the Status column on the reports page, allowing for quick task status updates.

--- a/scripts.js
+++ b/scripts.js
@@ -978,8 +978,8 @@ jQuery(document).ready(function ($) {
             action: 'ptt_run_self_tests',
             nonce: ptt_ajax_object.nonce
         }).done(function (response) {
-            if (response.success) {
-                const results = response.data.results || response.data;
+            if (response.success && response.data && Array.isArray(response.data.results)) {
+                const results = response.data.results;
                 let tableHtml = '<table class="wp-list-table widefat striped"><thead><tr><th>Test Name</th><th>Status</th><th>Message</th></tr></thead><tbody>';
                 results.forEach(function (result) {
                     tableHtml += `<tr>
@@ -989,12 +989,14 @@ jQuery(document).ready(function ($) {
                     </tr>`;
                 });
                 tableHtml += '</tbody></table>';
-                $resultsContainer.append(tableHtml);
+                $resultsContainer.html(tableHtml); // Use .html() to clear previous results
                 if (response.data.time) {
                     $('#ptt-last-test-time').text('Tests Last Ran at ' + response.data.time);
                 }
             } else {
-                $resultsContainer.append('<p class="error">An error occurred while running tests.</p>');
+                // Handle cases where the response is not what was expected
+                let errorMessage = '<p class="status-fail">An error occurred while running tests. The server returned an unexpected response, which may indicate a fatal error or that a sub-process was interrupted.</p>';
+                $resultsContainer.html(errorMessage);
             }
         }).fail(function () {
             $resultsContainer.append('<p class="error">A server error occurred.</p>');

--- a/self-test.php
+++ b/self-test.php
@@ -109,6 +109,207 @@ function ptt_run_self_tests_callback() {
     } else {
          $results[] = ['name' => 'Calculate Total Time', 'status' => 'Fail', 'message' => 'Could not create post for calculation test.'];
     }
+
+    // Test 4: Concurrent Task Prevention
+    $test_user_id = wp_insert_user([
+        'user_login' => 'ptt_test_user_' . wp_generate_password(4, false),
+        'user_pass'  => wp_generate_password(),
+        'role'       => 'subscriber'
+    ]);
+    $concurrent_post_id = wp_insert_post([
+        'post_type'   => 'project_task',
+        'post_title'  => 'CONCURRENT TEST',
+        'post_status' => 'publish',
+        'post_author' => $test_user_id
+    ]);
+    update_field('start_time', '2025-07-21 10:00:00', $concurrent_post_id);
+    update_field('stop_time', '', $concurrent_post_id);
+
+    $active_id = ptt_has_active_task($test_user_id);
+    if ($active_id === $concurrent_post_id) {
+        $results[] = ['name' => 'Concurrent Task Prevention (Active)', 'status' => 'Pass', 'message' => 'Active task detected correctly.'];
+    } else {
+        $results[] = ['name' => 'Concurrent Task Prevention (Active)', 'status' => 'Fail', 'message' => 'Active task ID mismatch.'];
+    }
+
+    update_field('stop_time', '2025-07-21 11:00:00', $concurrent_post_id);
+    $inactive_id = ptt_has_active_task($test_user_id);
+    if ($inactive_id === 0) {
+        $results[] = ['name' => 'Concurrent Task Prevention (Inactive)', 'status' => 'Pass', 'message' => 'No active task after stop time.'];
+    } else {
+        $results[] = ['name' => 'Concurrent Task Prevention (Inactive)', 'status' => 'Fail', 'message' => 'Task still reported active.'];
+    }
+
+    wp_delete_post($concurrent_post_id, true);
+    wp_delete_user($test_user_id);
+
+    // Test 5: Status Update via AJAX
+    $status_term = wp_insert_term('SELF TEST STATUS ' . wp_rand(), 'task_status');
+    $status_post = wp_insert_post([
+        'post_type'   => 'project_task',
+        'post_title'  => 'STATUS TEST',
+        'post_status' => 'publish'
+    ]);
+    $_POST = [
+        'nonce'     => wp_create_nonce('ptt_ajax_nonce'),
+        'post_id'   => $status_post,
+        'status_id' => $status_term['term_id']
+    ];
+    add_filter('wp_die_handler', function(){ return 'ptt_test_die_handler'; });
+    function ptt_test_die_handler($message){ echo $message; }
+    ob_start();
+    ptt_update_task_status_callback();
+    ob_get_clean();
+    remove_filter('wp_die_handler', 'ptt_test_die_handler');
+
+    $assigned = has_term($status_term['term_id'], 'task_status', $status_post);
+    if ($assigned) {
+        $results[] = ['name' => 'Status Update Callback', 'status' => 'Pass', 'message' => 'Status updated via AJAX successfully.'];
+    } else {
+        $results[] = ['name' => 'Status Update Callback', 'status' => 'Fail', 'message' => 'Status update failed.'];
+    }
+
+    wp_delete_post($status_post, true);
+    wp_delete_term($status_term['term_id'], 'task_status');
+
+    // Test 6: Multi-Session Calculation
+    $multi_post = wp_insert_post([
+        'post_type'   => 'project_task',
+        'post_title'  => 'MULTI SESSION TEST',
+        'post_status' => 'publish'
+    ]);
+    $sessions = [
+        [
+            'session_start_time'      => '2025-07-22 09:00:00',
+            'session_stop_time'       => '2025-07-22 10:00:00',
+            'session_calculated_duration' => '',
+            'session_manual_override' => 0,
+            'session_manual_duration' => ''
+        ],
+        [
+            'session_start_time'      => '',
+            'session_stop_time'       => '',
+            'session_calculated_duration' => '',
+            'session_manual_override' => 1,
+            'session_manual_duration' => 0.5
+        ],
+        [
+            'session_start_time'      => '2025-07-22 11:00:00',
+            'session_stop_time'       => '',
+            'session_calculated_duration' => '',
+            'session_manual_override' => 0,
+            'session_manual_duration' => ''
+        ]
+    ];
+    update_field('sessions', $sessions, $multi_post);
+    $total_sessions = ptt_get_total_sessions_duration($multi_post);
+    if ($total_sessions == 1.5) {
+        $results[] = ['name' => 'Multi-Session Duration', 'status' => 'Pass', 'message' => 'Correctly calculated 1.50 hours from sessions.'];
+    } else {
+        $results[] = ['name' => 'Multi-Session Duration', 'status' => 'Fail', 'message' => 'Expected 1.50, got ' . $total_sessions];
+    }
+    wp_delete_post($multi_post, true);
+
+    // Test 7: Shortcode Rendering
+    $today_start = current_time('Y-m-d 00:00:00');
+    $today_end   = current_time('Y-m-d 23:59:59');
+    $planner_html = ptt_render_planner_tasks(get_current_user_id(), $today_start, $today_end);
+    if (!empty($planner_html) && strpos($planner_html, '<ul class="ptt-task-planner">') !== false) {
+        $results[] = ['name' => 'Planner Shortcodes', 'status' => 'Pass', 'message' => 'Planner HTML rendered.'];
+    } else {
+        $results[] = ['name' => 'Planner Shortcodes', 'status' => 'Fail', 'message' => 'Planner HTML missing or malformed.'];
+    }
+
+    // Test 8: Reporting Logic
+    $report_client  = wp_insert_term('REPORT CLIENT ' . wp_rand(), 'client');
+    $report_project = wp_insert_term('REPORT PROJECT ' . wp_rand(), 'project');
+    $report_status  = wp_insert_term('REPORT STATUS ' . wp_rand(), 'task_status');
+    $admin_id = get_current_user_id();
+    $report_post1 = wp_insert_post([
+        'post_type'   => 'project_task',
+        'post_title'  => 'REPORT POST 1',
+        'post_status' => 'publish',
+        'post_author' => $admin_id
+    ]);
+    wp_set_object_terms($report_post1, $report_client['term_id'], 'client');
+    wp_set_object_terms($report_post1, $report_project['term_id'], 'project');
+    wp_set_object_terms($report_post1, $report_status['term_id'], 'task_status');
+    update_field('start_time', '2025-07-20 08:00:00', $report_post1);
+    update_field('stop_time', '2025-07-20 09:00:00', $report_post1);
+    ptt_calculate_and_save_duration($report_post1);
+    $report_post2 = wp_insert_post([
+        'post_type'   => 'project_task',
+        'post_title'  => 'REPORT POST 2',
+        'post_status' => 'publish',
+        'post_author' => $admin_id
+    ]);
+    wp_set_object_terms($report_post2, $report_client['term_id'], 'client');
+    wp_set_object_terms($report_post2, $report_project['term_id'], 'project');
+    wp_set_object_terms($report_post2, $report_status['term_id'], 'task_status');
+    update_field('start_time', '2025-07-21 08:00:00', $report_post2);
+    update_field('stop_time', '2025-07-21 10:00:00', $report_post2);
+    ptt_calculate_and_save_duration($report_post2);
+    $other_user = wp_insert_user([
+        'user_login' => 'ptt_other_' . wp_generate_password(4, false),
+        'user_pass'  => wp_generate_password(),
+        'role'       => 'subscriber'
+    ]);
+    $report_post3 = wp_insert_post([
+        'post_type'   => 'project_task',
+        'post_title'  => 'REPORT POST 3',
+        'post_status' => 'publish',
+        'post_author' => $other_user
+    ]);
+    wp_set_object_terms($report_post3, $report_client['term_id'], 'client');
+    wp_set_object_terms($report_post3, $report_project['term_id'], 'project');
+    wp_set_object_terms($report_post3, $report_status['term_id'], 'task_status');
+    update_field('start_time', '2025-07-21 08:00:00', $report_post3);
+    update_field('stop_time', '2025-07-21 09:00:00', $report_post3);
+    ptt_calculate_and_save_duration($report_post3);
+
+    $args = [
+        'post_type'      => 'project_task',
+        'posts_per_page' => -1,
+        'post_status'    => 'publish',
+        'orderby'        => ['author' => 'ASC', 'date' => 'ASC'],
+        'author'         => $admin_id,
+        'tax_query'      => [
+            [
+                'taxonomy' => 'client',
+                'field'    => 'term_id',
+                'terms'    => $report_client['term_id'],
+            ],
+        ],
+        'date_query'     => [
+            [
+                'after'     => '2025-07-19 00:00:00',
+                'before'    => '2025-07-22 23:59:59',
+                'inclusive' => true,
+            ],
+        ],
+    ];
+    $report_query = new WP_Query($args);
+    $grand = 0.0;
+    if ($report_query->have_posts()) {
+        foreach ($report_query->posts as $rp) {
+            $grand += (float) get_field('calculated_duration', $rp->ID);
+        }
+    }
+    wp_reset_postdata();
+
+    if ($report_query->post_count === 2 && number_format($grand, 2) === '3.00') {
+        $results[] = ['name' => 'Reporting Logic', 'status' => 'Pass', 'message' => 'Report query returned expected posts and total.'];
+    } else {
+        $results[] = ['name' => 'Reporting Logic', 'status' => 'Fail', 'message' => 'Unexpected report results.'];
+    }
+
+    wp_delete_post($report_post1, true);
+    wp_delete_post($report_post2, true);
+    wp_delete_post($report_post3, true);
+    wp_delete_user($other_user);
+    wp_delete_term($report_client['term_id'], 'client');
+    wp_delete_term($report_project['term_id'], 'project');
+    wp_delete_term($report_status['term_id'], 'task_status');
     
     $timestamp = current_time( 'timestamp' );
     update_option( 'ptt_tests_last_run', $timestamp );


### PR DESCRIPTION
## Summary
- expand the self-test module with additional tests
- bump version to 1.7.9
- document new version in changelog
- note self-test changes in reports module docs

## Testing
- `php -l self-test.php`
- `php -l project-task-tracker.php`
- `php -l reports.php`

------
https://chatgpt.com/codex/tasks/task_b_687ffe8f31f4832e92987b86dc5edb15