### PR TITLE
Move time calc logic to separate file

### DIFF
--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.17
+ * Version:           1.7.18
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.17' );
+define( 'PTT_VERSION', '1.7.18' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -31,7 +31,7 @@ define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
  * 3.0  CPT & TAXONOMY REGISTRATION
  * 4.0  ACF FIELD REGISTRATION
  * 5.0  ENQUEUE SCRIPTS & STYLES
- * 6.0  CORE TIME CALCULATION LOGIC
+ * 6.0  CORE TIME CALCULATION LOGIC (see time-calculations.php)
  * 7.0  ADMIN UI (CPT EDITOR)
  * 8.0  AJAX HANDLERS
  * 9.0  FRONT-END SHORTCODE [task-enter] (see shortcodes.php)
@@ -42,6 +42,7 @@ define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
  */
 
 // Load plugin modules
+require_once PTT_PLUGIN_DIR . 'time-calculations.php';
 require_once PTT_PLUGIN_DIR . 'shortcodes.php';
 require_once PTT_PLUGIN_DIR . 'self-test.php';
 require_once PTT_PLUGIN_DIR . 'reports.php';
@@ -513,180 +514,10 @@ add_action( 'wp_enqueue_scripts', 'ptt_enqueue_assets' );
 
 
 // =================================================================
-// 6.0 CORE TIME CALCULATION LOGIC
+// 6.0 CORE TIME CALCULATION LOGIC (see time-calculations.php)
 // =================================================================
+// Functions located in time-calculations.php
 
-/**
- * Calculates duration between start and stop time and saves it to a custom field.
- *
- * @param int $post_id The ID of the post to calculate.
- * @return float The calculated duration in decimal hours.
- */
-function ptt_calculate_and_save_duration( $post_id ) {
-    $sessions = get_field( 'sessions', $post_id );
-    $duration = 0.00;
-
-    if ( ! empty( $sessions ) ) {
-        $duration = ptt_get_total_sessions_duration( $post_id );
-    } else {
-        $manual_override = get_field( 'manual_override', $post_id );
-
-        if ( $manual_override ) {
-            $manual_duration = get_field( 'manual_duration', $post_id );
-            $duration        = $manual_duration ? (float) $manual_duration : 0.00;
-        } else {
-            $start_time_str = get_field( 'start_time', $post_id );
-            $stop_time_str  = get_field( 'stop_time', $post_id );
-
-            if ( $start_time_str && $stop_time_str ) {
-                try {
-                    // Always use UTC for calculations to avoid timezone issues.
-                    $start_time = new DateTime( $start_time_str, new DateTimeZone('UTC') );
-                    $stop_time  = new DateTime( $stop_time_str, new DateTimeZone('UTC') );
-
-                    if ( $stop_time > $start_time ) {
-                        $diff_seconds   = $stop_time->getTimestamp() - $start_time->getTimestamp();
-                        $duration_hours = $diff_seconds / 3600;
-                        $duration       = ceil( $duration_hours * 100 ) / 100;
-                    }
-                } catch ( Exception $e ) {
-                    $duration = 0.00;
-                }
-            }
-        }
-    }
-
-    $formatted_duration = number_format( (float) $duration, 2, '.', '' );
-    update_field( 'calculated_duration', $formatted_duration, $post_id );
-
-    return $formatted_duration;
-}
-
-/**
- * Returns the index of any active session for a task.
- *
- * @param int $post_id The task ID.
- * @return int|false The active session index or false if none.
- */
-function ptt_get_active_session_index( $post_id ) {
-    $sessions = get_field( 'sessions', $post_id );
-    if ( ! empty( $sessions ) && is_array( $sessions ) ) {
-        foreach ( $sessions as $index => $session ) {
-            if ( ! empty( $session['session_start_time'] ) && empty( $session['session_stop_time'] ) ) {
-                return $index;
-            }
-        }
-    }
-    return false;
-}
-
-/**
- * Calculates and saves duration for a specific session row.
- *
- * @param int $post_id The task ID.
- * @param int $index   Session index (0 based).
- * @return string      Formatted duration hours.
- */
-function ptt_calculate_session_duration( $post_id, $index ) {
-    $sessions = get_field( 'sessions', $post_id );
-    if ( empty( $sessions ) || ! isset( $sessions[ $index ] ) ) {
-        return '0.00';
-    }
-
-    $session = $sessions[ $index ];
-
-    if ( ! empty( $session['session_manual_override'] ) ) {
-        $duration = isset( $session['session_manual_duration'] ) ? floatval( $session['session_manual_duration'] ) : 0.00;
-    } else {
-        $start_time_str = isset( $session['session_start_time'] ) ? $session['session_start_time'] : '';
-        $stop_time_str  = isset( $session['session_stop_time'] ) ? $session['session_stop_time'] : '';
-        $duration       = 0.00;
-
-        if ( $start_time_str && $stop_time_str ) {
-            try {
-                // Always use UTC for calculations
-                $start_time = new DateTime( $start_time_str, new DateTimeZone('UTC') );
-                $stop_time  = new DateTime( $stop_time_str, new DateTimeZone('UTC') );
-
-                if ( $stop_time > $start_time ) {
-                    $diff_seconds   = $stop_time->getTimestamp() - $start_time->getTimestamp();
-                    $duration_hours = $diff_seconds / 3600;
-                    $duration       = ceil( $duration_hours * 100 ) / 100;
-                }
-            } catch ( Exception $e ) {
-                $duration = 0.00;
-            }
-        }
-    }
-
-    $formatted = number_format( (float) $duration, 2, '.', '' );
-    update_sub_field( array( 'sessions', $index + 1, 'session_calculated_duration' ), $formatted, $post_id );
-    return $formatted;
-}
-
-/**
- * Calculates the total duration of all sessions for a task.
- *
- * @param int $post_id Task ID.
- * @return float Total hours rounded to two decimals.
- */
-function ptt_get_total_sessions_duration( $post_id ) {
-    $sessions = get_field( 'sessions', $post_id );
-    $total    = 0.0;
-
-    if ( ! empty( $sessions ) && is_array( $sessions ) ) {
-        foreach ( $sessions as $session ) {
-            if ( ! empty( $session['session_manual_override'] ) ) {
-                $dur = isset( $session['session_manual_duration'] ) ? floatval( $session['session_manual_duration'] ) : 0.0;
-            } else {
-                $start = isset( $session['session_start_time'] ) ? $session['session_start_time'] : '';
-                $stop  = isset( $session['session_stop_time'] ) ? $session['session_stop_time'] : '';
-                $dur   = 0.0;
-
-                if ( $start && $stop ) {
-                    try {
-                        $start_time = new DateTime( $start, new DateTimeZone('UTC') );
-                        $stop_time  = new DateTime( $stop, new DateTimeZone('UTC') );
-                        if ( $stop_time > $start_time ) {
-                            $diff_seconds = $stop_time->getTimestamp() - $start_time->getTimestamp();
-                            $dur          = $diff_seconds / 3600;
-                        }
-                    } catch ( Exception $e ) {
-                        $dur = 0.0;
-                    }
-                }
-            }
-
-            $total += $dur;
-        }
-    }
-
-    $total = ceil( $total * 100 ) / 100;
-    return $total;
-}
-
-
-/**
- * Recalculates duration whenever a task post is saved.
- * Hooks into ACF's save_post action for reliability.
- *
- * @param int $post_id The post ID.
- */
-function ptt_recalculate_on_save( $post_id ) {
-    if ( get_post_type( $post_id ) === 'project_task' ) {
-        $sessions = get_field( 'sessions', $post_id );
-        if ( ! empty( $sessions ) ) {
-            foreach ( array_keys( $sessions ) as $index ) {
-                ptt_calculate_session_duration( $post_id, $index );
-            }
-        }
-        ptt_calculate_and_save_duration( $post_id );
-    }
-}
-add_action( 'acf/save_post', 'ptt_recalculate_on_save', 20 );
-
-
-// =================================================================
 // 7.0 ADMIN UI (CPT EDITOR)
 // =================================================================
 

--- a/readme.md
+++ b/readme.md
@@ -121,6 +121,9 @@ A: The total time tracked for the task has exceeded the hours you set in the "Ma
 ***
 
 ## 📋 Changelog
+### Version 1.7.18 (2025-07-23)
+* **Improved:** Moved core time calculation logic to a separate file for better organization.
+
 ### Version 1.7.17 (2025-07-23)
 * **Feature:** Added "Task Focused" list view mode to reports, with a custom toggle switch UI.
 * **Feature:** In Task Focused view, tasks with multiple statuses appear as a line item for each status.

--- a/time-calculations.php
+++ b/time-calculations.php
@@ -1,0 +1,178 @@
+<?php
+// If this file is called directly, abort.
+if ( ! defined( "WPINC" ) ) {
+    die;
+}
+
+// 6.0 CORE TIME CALCULATION LOGIC
+// =================================================================
+
+/**
+ * Calculates duration between start and stop time and saves it to a custom field.
+ *
+ * @param int $post_id The ID of the post to calculate.
+ * @return float The calculated duration in decimal hours.
+ */
+function ptt_calculate_and_save_duration( $post_id ) {
+    $sessions = get_field( 'sessions', $post_id );
+    $duration = 0.00;
+
+    if ( ! empty( $sessions ) ) {
+        $duration = ptt_get_total_sessions_duration( $post_id );
+    } else {
+        $manual_override = get_field( 'manual_override', $post_id );
+
+        if ( $manual_override ) {
+            $manual_duration = get_field( 'manual_duration', $post_id );
+            $duration        = $manual_duration ? (float) $manual_duration : 0.00;
+        } else {
+            $start_time_str = get_field( 'start_time', $post_id );
+            $stop_time_str  = get_field( 'stop_time', $post_id );
+
+            if ( $start_time_str && $stop_time_str ) {
+                try {
+                    // Always use UTC for calculations to avoid timezone issues.
+                    $start_time = new DateTime( $start_time_str, new DateTimeZone('UTC') );
+                    $stop_time  = new DateTime( $stop_time_str, new DateTimeZone('UTC') );
+
+                    if ( $stop_time > $start_time ) {
+                        $diff_seconds   = $stop_time->getTimestamp() - $start_time->getTimestamp();
+                        $duration_hours = $diff_seconds / 3600;
+                        $duration       = ceil( $duration_hours * 100 ) / 100;
+                    }
+                } catch ( Exception $e ) {
+                    $duration = 0.00;
+                }
+            }
+        }
+    }
+
+    $formatted_duration = number_format( (float) $duration, 2, '.', '' );
+    update_field( 'calculated_duration', $formatted_duration, $post_id );
+
+    return $formatted_duration;
+}
+
+/**
+ * Returns the index of any active session for a task.
+ *
+ * @param int $post_id The task ID.
+ * @return int|false The active session index or false if none.
+ */
+function ptt_get_active_session_index( $post_id ) {
+    $sessions = get_field( 'sessions', $post_id );
+    if ( ! empty( $sessions ) && is_array( $sessions ) ) {
+        foreach ( $sessions as $index => $session ) {
+            if ( ! empty( $session['session_start_time'] ) && empty( $session['session_stop_time'] ) ) {
+                return $index;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Calculates and saves duration for a specific session row.
+ *
+ * @param int $post_id The task ID.
+ * @param int $index   Session index (0 based).
+ * @return string      Formatted duration hours.
+ */
+function ptt_calculate_session_duration( $post_id, $index ) {
+    $sessions = get_field( 'sessions', $post_id );
+    if ( empty( $sessions ) || ! isset( $sessions[ $index ] ) ) {
+        return '0.00';
+    }
+
+    $session = $sessions[ $index ];
+
+    if ( ! empty( $session['session_manual_override'] ) ) {
+        $duration = isset( $session['session_manual_duration'] ) ? floatval( $session['session_manual_duration'] ) : 0.00;
+    } else {
+        $start_time_str = isset( $session['session_start_time'] ) ? $session['session_start_time'] : '';
+        $stop_time_str  = isset( $session['session_stop_time'] ) ? $session['session_stop_time'] : '';
+        $duration       = 0.00;
+
+        if ( $start_time_str && $stop_time_str ) {
+            try {
+                // Always use UTC for calculations
+                $start_time = new DateTime( $start_time_str, new DateTimeZone('UTC') );
+                $stop_time  = new DateTime( $stop_time_str, new DateTimeZone('UTC') );
+
+                if ( $stop_time > $start_time ) {
+                    $diff_seconds   = $stop_time->getTimestamp() - $start_time->getTimestamp();
+                    $duration_hours = $diff_seconds / 3600;
+                    $duration       = ceil( $duration_hours * 100 ) / 100;
+                }
+            } catch ( Exception $e ) {
+                $duration = 0.00;
+            }
+        }
+    }
+
+    $formatted = number_format( (float) $duration, 2, '.', '' );
+    update_sub_field( array( 'sessions', $index + 1, 'session_calculated_duration' ), $formatted, $post_id );
+    return $formatted;
+}
+
+/**
+ * Calculates the total duration of all sessions for a task.
+ *
+ * @param int $post_id Task ID.
+ * @return float Total hours rounded to two decimals.
+ */
+function ptt_get_total_sessions_duration( $post_id ) {
+    $sessions = get_field( 'sessions', $post_id );
+    $total    = 0.0;
+
+    if ( ! empty( $sessions ) && is_array( $sessions ) ) {
+        foreach ( $sessions as $session ) {
+            if ( ! empty( $session['session_manual_override'] ) ) {
+                $dur = isset( $session['session_manual_duration'] ) ? floatval( $session['session_manual_duration'] ) : 0.0;
+            } else {
+                $start = isset( $session['session_start_time'] ) ? $session['session_start_time'] : '';
+                $stop  = isset( $session['session_stop_time'] ) ? $session['session_stop_time'] : '';
+                $dur   = 0.0;
+
+                if ( $start && $stop ) {
+                    try {
+                        $start_time = new DateTime( $start, new DateTimeZone('UTC') );
+                        $stop_time  = new DateTime( $stop, new DateTimeZone('UTC') );
+                        if ( $stop_time > $start_time ) {
+                            $diff_seconds = $stop_time->getTimestamp() - $start_time->getTimestamp();
+                            $dur          = $diff_seconds / 3600;
+                        }
+                    } catch ( Exception $e ) {
+                        $dur = 0.0;
+                    }
+                }
+            }
+
+            $total += $dur;
+        }
+    }
+
+    $total = ceil( $total * 100 ) / 100;
+    return $total;
+}
+
+
+/**
+ * Recalculates duration whenever a task post is saved.
+ * Hooks into ACF's save_post action for reliability.
+ *
+ * @param int $post_id The post ID.
+ */
+function ptt_recalculate_on_save( $post_id ) {
+    if ( get_post_type( $post_id ) === 'project_task' ) {
+        $sessions = get_field( 'sessions', $post_id );
+        if ( ! empty( $sessions ) ) {
+            foreach ( array_keys( $sessions ) as $index ) {
+                ptt_calculate_session_duration( $post_id, $index );
+            }
+        }
+        ptt_calculate_and_save_duration( $post_id );
+    }
+}
+add_action( 'acf/save_post', 'ptt_recalculate_on_save', 20 );
+


### PR DESCRIPTION
## Summary
- move core time calculation logic into `time-calculations.php`
- load new module and bump plugin version to 1.7.18
- document change in README changelog

## Testing
- `php -l project-task-tracker.php`
- `php -l time-calculations.php`
- `php self-test.php` *(fails: no output due to missing WordPress environment)*

------
https://chatgpt.com/codex/tasks/task_b_68816c94484c832ea0ecacdc030fd620