### PR TITLE
Rename Author labels to Assignee

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,9 @@ A: The total time tracked for the task has exceeded the hours you set in the "Ma
 ***
 
 ## 📋 Changelog
+### Version 1.7.6 (2025-07-21)
+* **Admin:** Author column and meta box now labeled "Assignee" for Tasks.
+
 ### Version 1.7.4 (2025-07-21)
 * **Docs:** Added detailed user instructions and an FAQ section to the Readme file.
 * **Feature:** On screen debugger code for  timer in scripts.js - comment out later


### PR DESCRIPTION
## Summary
- adjust Author column label to Assignee
- override Author metabox title with Assignee
- replace Author text strings when editing tasks
- bump version to 1.7.6

## Testing
- `php -l project-task-tracker.php`
- `php -l readme.md`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_6888ff748360832e8d847e47745a6601