### PR TITLE
feat: add admin changelog page and reorder menu

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@
 All notable changes to the "KISS - Project & Task Time Tracker" plugin will be documented in this file.
 
 ---
+### Version 1.7.30 (2025-07-30)
+* **Feature**: Added in-dashboard changelog viewer and reorganized Tasks menu order.
+* **Change**: Moved dynamic version number display from Settings to Changelog menu item.
+
+---
 ### Version 1.7.29 (2025-07-30)
 * **Dev**: Improved date range self-test to limit scope to test posts and show missing or unexpected tasks with actionable messages.
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.29
+ * Version:           1.7.30
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.29' );
+define( 'PTT_VERSION', '1.7.30' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/self-test.php
+++ b/self-test.php
@@ -16,13 +16,86 @@ function ptt_add_settings_submenu_page() {
     add_submenu_page(
         'edit.php?post_type=project_task', // Parent slug
         'Tracker Settings',                // Page title
-        'Settings - v' . PTT_VERSION,      // Menu title - UPDATED
+        'Settings',                        // Menu title
         'manage_options',                  // Capability
         'ptt-self-test',                   // Menu slug
         'ptt_self_test_page_html'          // Function
     );
 }
-add_action('admin_menu', 'ptt_add_settings_submenu_page');
+add_action( 'admin_menu', 'ptt_add_settings_submenu_page' );
+
+/**
+ * Adds the "Changelog" link under the Tasks CPT menu.
+ */
+function ptt_add_changelog_submenu_page() {
+    add_submenu_page(
+        'edit.php?post_type=project_task', // Parent slug
+        'Plugin Changelog',               // Page title
+        'Changelog - v' . PTT_VERSION,    // Menu title
+        'manage_options',                 // Capability
+        'ptt-changelog',                  // Menu slug
+        'ptt_changelog_page_html'         // Function
+    );
+}
+add_action( 'admin_menu', 'ptt_add_changelog_submenu_page' );
+
+/**
+ * Renders the Changelog page HTML.
+ */
+function ptt_changelog_page_html() {
+    $file_path = PTT_PLUGIN_DIR . 'changelog.md';
+    $content   = '';
+
+    if ( file_exists( $file_path ) ) {
+        $lines   = file( $file_path );
+        $preview = array_slice( $lines, 0, 500 );
+        $content = implode( '', $preview );
+    } else {
+        $content = 'changelog.md not found.';
+    }
+
+    echo '<div class="wrap">';
+    echo '<h1>Plugin Changelog</h1>';
+    echo '<pre>' . esc_html( $content ) . '</pre>';
+    echo '<p><em>To view entire changelog, please open the changelog.md file in a text viewer.</em></p>';
+    echo '</div>';
+}
+
+/**
+ * Reorders the Tasks menu items.
+ */
+function ptt_reorder_tasks_menu() {
+    global $submenu;
+
+    if ( ! isset( $submenu['edit.php?post_type=project_task'] ) ) {
+        return;
+    }
+
+    $ordered = [
+        'edit.php?post_type=project_task',
+        'post-new.php?post_type=project_task',
+        'edit-tags.php?taxonomy=post_tag&post_type=project_task',
+        'edit-tags.php?taxonomy=client&post_type=project_task',
+        'edit-tags.php?taxonomy=project&post_type=project_task',
+        'edit-tags.php?taxonomy=task_status&post_type=project_task',
+        'ptt-reports',
+        'ptt-self-test',
+        'ptt-changelog',
+    ];
+
+    $lookup = [];
+    foreach ( $submenu['edit.php?post_type=project_task'] as $item ) {
+        $lookup[ $item[2] ] = $item;
+    }
+
+    $submenu['edit.php?post_type=project_task'] = [];
+    foreach ( $ordered as $slug ) {
+        if ( isset( $lookup[ $slug ] ) ) {
+            $submenu['edit.php?post_type=project_task'][] = $lookup[ $slug ];
+        }
+    }
+}
+add_action( 'admin_menu', 'ptt_reorder_tasks_menu', 999 );
 
 /**
  * Renders the Self Test page HTML.


### PR DESCRIPTION
## Summary
- add dashboard changelog viewer under Tasks menu with versioned label
- reorder Tasks submenu items and move version display from Settings
- bump plugin to v1.7.30

## Testing
- `php -l project-task-tracker.php`
- `php -l self-test.php`


------
https://chatgpt.com/codex/tasks/task_b_688ae27dfac4832eaa9ff3af02a310ba