### PR TITLE
Add dedicated Assignee field

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,16 @@
 All notable changes to the "KISS - Project & Task Time Tracker" plugin will be documented in this file.
 
 ---
+### Version 1.7.32 (2025-08-01)
+* **Feature:** Added a Settings utility to synchronize Authors into the Assignee field.
+* **Feature:** Display the Assignee alongside Author in the All Tasks list.
+
+---
+### Version 1.7.31 (2025-08-01)
+* **Change:** Restored WordPress default "Author" label and added a new "Assignee" field.
+* **Feature:** Reports now filter and display using the custom "Assignee" field.
+
+---
 ### Version 1.7.30 (2025-07-30)
 * **Feature**: Added in-dashboard changelog viewer and reorganized Tasks menu order.
 * **Change**: Moved dynamic version number display from Settings to Changelog menu item.

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.30
+ * Version:           1.7.32
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.30' );
+define( 'PTT_VERSION', '1.7.32' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -692,35 +692,103 @@ add_action( 'acf/save_post', 'ptt_recalculate_on_save', 20 );
 // =================================================================
 
 /**
- * Renames the default Author column to "Assignee" on the Tasks list table.
- *
- * @param array $columns Existing column labels.
- * @return array Modified column labels.
+ * Adds a combined Author & Assignee meta box on the Task editor.
  */
-function ptt_rename_author_column( $columns ) {
-    if ( isset( $columns['author'] ) ) {
-        $columns['author'] = __( 'Assignee', 'ptt' );
-    }
-    return $columns;
-}
-add_filter( 'manage_project_task_posts_columns', 'ptt_rename_author_column' );
-
-/**
- * Replaces the Author meta box with an "Assignee" meta box on the Task editor.
- */
-function ptt_assignee_meta_box() {
+function ptt_author_assignee_meta_box_setup() {
     remove_meta_box( 'authordiv', 'project_task', 'core' );
     add_meta_box(
-        'assigneediv',
-        __( 'Assignee', 'ptt' ),
-        'post_author_meta_box',
+        'ptt-author-assignee',
+        __( 'Author & Assignee', 'ptt' ),
+        'ptt_author_assignee_meta_box',
         'project_task',
         'side',
         'core',
         [ '__back_compat_meta_box' => true ]
     );
 }
-add_action( 'add_meta_boxes_project_task', 'ptt_assignee_meta_box' );
+add_action( 'add_meta_boxes_project_task', 'ptt_author_assignee_meta_box_setup' );
+
+/**
+ * Renders the Author & Assignee meta box.
+ *
+ * @param WP_Post $post Current post object.
+ */
+function ptt_author_assignee_meta_box( $post ) {
+    post_author_meta_box( $post );
+
+    $assignee = (int) get_post_meta( $post->ID, 'ptt_assignee', true );
+    wp_nonce_field( 'ptt_save_assignee', 'ptt_assignee_nonce' );
+
+    echo '<p>';
+    echo '<label for="ptt_assignee">' . esc_html__( 'Assignee', 'ptt' ) . '</label><br />';
+    wp_dropdown_users(
+        [
+            'name'            => 'ptt_assignee',
+            'id'              => 'ptt_assignee',
+            'role__in'        => [ 'author', 'editor', 'administrator' ],
+            'selected'        => $assignee,
+            'show_option_none'=> __( 'No Assignee', 'ptt' ),
+        ]
+    );
+    echo '</p>';
+}
+
+/**
+ * Saves the Assignee field.
+ *
+ * @param int $post_id Post ID.
+ */
+function ptt_save_assignee_meta( $post_id ) {
+    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+        return;
+    }
+
+    if ( ! isset( $_POST['ptt_assignee_nonce'] ) || ! wp_verify_nonce( $_POST['ptt_assignee_nonce'], 'ptt_save_assignee' ) ) {
+        return;
+    }
+
+    if ( ! current_user_can( 'edit_post', $post_id ) ) {
+        return;
+    }
+
+    $assignee = isset( $_POST['ptt_assignee'] ) ? absint( $_POST['ptt_assignee'] ) : 0;
+    update_post_meta( $post_id, 'ptt_assignee', $assignee );
+}
+add_action( 'save_post_project_task', 'ptt_save_assignee_meta' );
+
+
+/**
+ * Adds Assignee column to the Tasks list table.
+ *
+ * @param array $columns Existing columns.
+ * @return array Modified columns.
+ */
+function ptt_add_assignee_column( $columns ) {
+    $new = [];
+    foreach ( $columns as $key => $label ) {
+        $new[ $key ] = $label;
+        if ( 'author' === $key ) {
+            $new['ptt_assignee'] = __( 'Assignee', 'ptt' );
+        }
+    }
+    return $new;
+}
+add_filter( 'manage_project_task_posts_columns', 'ptt_add_assignee_column' );
+
+/**
+ * Renders the Assignee column content.
+ *
+ * @param string $column  Column name.
+ * @param int    $post_id Post ID.
+ */
+function ptt_render_assignee_column( $column, $post_id ) {
+    if ( 'ptt_assignee' === $column ) {
+        $assignee_id = (int) get_post_meta( $post_id, 'ptt_assignee', true );
+        $name        = $assignee_id ? get_the_author_meta( 'display_name', $assignee_id ) : __( 'No Assignee', 'ptt' );
+        echo esc_html( $name );
+    }
+}
+add_action( 'manage_project_task_posts_custom_column', 'ptt_render_assignee_column', 10, 2 );
 
 
 // =================================================================

--- a/scripts.js
+++ b/scripts.js
@@ -1039,4 +1039,27 @@ jQuery(document).ready(function ($) {
     if ($('#ptt-run-self-tests').length) {
         $('#ptt-run-self-tests').trigger('click');
     }
+
+    $('#ptt-sync-authors').on('click', function () {
+        const $button = $(this);
+        const $result = $('#ptt-sync-authors-result');
+
+        $button.prop('disabled', true);
+        $result.text('Synchronizing...');
+
+        $.post(ptt_ajax_object.ajax_url, {
+            action: 'ptt_sync_authors_assignee',
+            nonce: ptt_ajax_object.nonce
+        }).done(function (response) {
+            if (response.success && typeof response.data.count !== 'undefined') {
+                $result.text('Synchronized ' + response.data.count + ' tasks.');
+            } else {
+                $result.text('Synchronization failed.');
+            }
+        }).fail(function () {
+            $result.text('Server error.');
+        }).always(function () {
+            $button.prop('disabled', false);
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- restore default Author label and add a combined Author & Assignee meta box
- allow tasks to store a separate Assignee user and filter reports by that field
- add a Settings utility to synchronize Authors into the Assignee field and show the Assignee column on the All Tasks screen
- document the change in the changelog

## Testing
- `php self-test.php`


------
https://chatgpt.com/codex/tasks/task_b_688d2d6845e4832eb8c37826781975ce