### PR TITLE
Fix assignee dropdown user query

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 All notable changes to the "KISS - Project & Task Time Tracker" plugin will be documented in this file.
 
+### Version 1.7.40
+* **Fixed:** Assignee dropdown in reports now queries by capability to reliably list Administrators, Editors, and Authors.
+
 ### Version 1.7.39
 Fix: Corrected taxonomy registration to properly display Client, Project, and Status menus under the "Tasks" CPT menu.
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.39
+ * Version:           1.7.40
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.39' );
+define( 'PTT_VERSION', '1.7.40' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/reports.php
+++ b/reports.php
@@ -157,7 +157,7 @@ function ptt_reports_page_html() {
                                                        wp_dropdown_users(
                                                                [
                                                                        'name'            => 'assignee_id',
-                                                                       'role__in'        => [ 'author', 'editor', 'administrator' ],
+                                                                       'capability'      => 'publish_posts',
                                                                        'show_option_all' => 'All Assignees',
                                                                        'selected'        => isset( $_REQUEST['assignee_id'] ) ? intval( $_REQUEST['assignee_id'] ) : 0,
                                                                ]


### PR DESCRIPTION
## Summary
- adjust reports page assignee dropdown to query by capability so Administrators, Editors, and Authors appear
- bump plugin version to 1.7.40 and update changelog

## Testing
- `php self-test.php`

------
https://chatgpt.com/codex/tasks/task_b_689120896b88832e88a9b4320d30a8ea