### PR TITLE
Fix assignee dropdown user query and add sync confirmation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "KISS - Project & Task Time Tracker" plugin will be documented in this file.
 
+### Version 1.7.41
+* **Added:** Confirmation dialog with "No" as the default before running "Synchronize Authors → Assignee" on the Self Test page.
+
+### Version 1.7.40
+* **Fixed:** Assignee dropdown in reports now queries by capability to reliably list Administrators, Editors, and Authors.
+
 ### Version 1.7.39
 Fix: Corrected taxonomy registration to properly display Client, Project, and Status menus under the "Tasks" CPT menu.
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.39
+ * Version:           1.7.41
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.39' );
+define( 'PTT_VERSION', '1.7.41' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -497,8 +497,14 @@ function ptt_enqueue_assets() {
     // Main CSS file (now in root)
     wp_enqueue_style( 'ptt-styles', PTT_PLUGIN_URL . 'styles.css', [], PTT_VERSION );
 
+    $deps = [ 'jquery' ];
+    if ( is_admin() ) {
+        $deps[] = 'jquery-ui-dialog';
+        wp_enqueue_style( 'wp-jquery-ui-dialog' );
+    }
+
     // Main JS file (now in root)
-    wp_enqueue_script( 'ptt-scripts', PTT_PLUGIN_URL . 'scripts.js', [ 'jquery' ], PTT_VERSION, true );
+    wp_enqueue_script( 'ptt-scripts', PTT_PLUGIN_URL . 'scripts.js', $deps, PTT_VERSION, true );
     
     // Localize script to pass data like nonces and AJAX URL
     wp_localize_script( 'ptt-scripts', 'ptt_ajax_object', [
@@ -508,7 +514,9 @@ function ptt_enqueue_assets() {
         'concurrent_error'      => __('You have another task running. Please stop it before starting a new one.', 'ptt'),
         'edit_post_link'        => admin_url('post.php?action=edit&post='),
         'todays_date_formatted' => date_i18n( get_option( 'date_format' ), current_time( 'timestamp' ) ),
-    ]);
+        'sync_authors_confirm'  => __( 'Are you sure you want to synchronize Authors to Assignee?', 'ptt' ),
+        'sync_authors_title'    => __( 'Confirm Synchronization', 'ptt' ),
+    ] );
 }
 // Enqueue for admin screens
 add_action( 'admin_enqueue_scripts', 'ptt_enqueue_assets' );

--- a/reports.php
+++ b/reports.php
@@ -157,7 +157,7 @@ function ptt_reports_page_html() {
                                                        wp_dropdown_users(
                                                                [
                                                                        'name'            => 'assignee_id',
-                                                                       'role__in'        => [ 'author', 'editor', 'administrator' ],
+                                                                       'capability'      => 'publish_posts',
                                                                        'show_option_all' => 'All Assignees',
                                                                        'selected'        => isset( $_REQUEST['assignee_id'] ) ? intval( $_REQUEST['assignee_id'] ) : 0,
                                                                ]

--- a/scripts.js
+++ b/scripts.js
@@ -1040,26 +1040,44 @@ jQuery(document).ready(function ($) {
         $('#ptt-run-self-tests').trigger('click');
     }
 
-    $('#ptt-sync-authors').on('click', function () {
+    $('#ptt-sync-authors').on('click', function (e) {
+        e.preventDefault();
         const $button = $(this);
         const $result = $('#ptt-sync-authors-result');
 
-        $button.prop('disabled', true);
-        $result.text('Synchronizing...');
-
-        $.post(ptt_ajax_object.ajax_url, {
-            action: 'ptt_sync_authors_assignee',
-            nonce: ptt_ajax_object.nonce
-        }).done(function (response) {
-            if (response.success && typeof response.data.count !== 'undefined') {
-                $result.text('Synchronized ' + response.data.count + ' tasks.');
-            } else {
-                $result.text('Synchronization failed.');
+        $('<div>' + ptt_ajax_object.sync_authors_confirm + '</div>').dialog({
+            modal: true,
+            title: ptt_ajax_object.sync_authors_title,
+            buttons: {
+                'Yes': function () {
+                    $(this).dialog('close');
+                    $button.prop('disabled', true);
+                    $result.text('Synchronizing...');
+                    $.post(ptt_ajax_object.ajax_url, {
+                        action: 'ptt_sync_authors_assignee',
+                        nonce: ptt_ajax_object.nonce
+                    }).done(function (response) {
+                        if (response.success && typeof response.data.count !== 'undefined') {
+                            $result.text('Synchronized ' + response.data.count + ' tasks.');
+                        } else {
+                            $result.text('Synchronization failed.');
+                        }
+                    }).fail(function () {
+                        $result.text('Server error.');
+                    }).always(function () {
+                        $button.prop('disabled', false);
+                    });
+                },
+                'No': function () {
+                    $(this).dialog('close');
+                }
+            },
+            open: function () {
+                $(this).parent().find('.ui-dialog-buttonpane button:contains("No")').focus();
+            },
+            close: function () {
+                $(this).remove();
             }
-        }).fail(function () {
-            $result.text('Server error.');
-        }).always(function () {
-            $button.prop('disabled', false);
         });
     });
 });


### PR DESCRIPTION
## Summary
- adjust reports page assignee dropdown to query by capability so Administrators, Editors, and Authors appear
- add confirmation dialog with default **No** before running **Synchronize Authors → Assignee** in Self Test
- bump plugin version to 1.7.41 and update changelog

## Testing
- `php self-test.php`


------
https://chatgpt.com/codex/tasks/task_b_689120896b88832e88a9b4320d30a8ea