### PR TITLE
Enable REST API access for Tasks CPT

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 All notable changes to the "KISS - Project & Task Time Tracker" plugin will be documented in this file.
 
 
+### Version 1.7.42
+* **Improved:** Tasks custom post type now exposes its data via the REST API by enabling `show_in_rest`.
+
 ### Version 1.7.41
 * **Added:** Confirmation dialog with "No" as the default before running "Synchronize Authors → Assignee" on the Self Test page.
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.7.41
+ * Version:           1.7.42
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.7.41' );
+define( 'PTT_VERSION', '1.7.42' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -143,6 +143,7 @@ function ptt_register_post_type() {
         'publicly_queryable' => true,
         'show_ui'            => true,
         'show_in_menu'       => true,
+        'show_in_rest'       => true,
         'query_var'          => true,
         'rewrite'            => [ 'slug' => 'project_task' ],
         'capability_type'    => 'post',


### PR DESCRIPTION
## Summary
- expose Tasks custom post type to the WordPress REST API
- bump plugin version to 1.7.42

## Testing
- `php self-test.php` *(fails: No output - WP environment not available)*
- `php -l project-task-tracker.php`


------
https://chatgpt.com/codex/tasks/task_b_68953519a0b4832ebb44e9918b752060