### PR TITLE
Link Today entries to task editor and show client, style timers with Silkscreen font

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 All notable changes to the "KISS - Project & Task Time Tracker" plugin will be documented in this file.
 
+## 1.9.3 - 2025-08-08
+
+* **Enhanced:** Timer and duration displays on the Today page now use the Silkscreen Google Font.
+
+## 1.9.2 - 2025-08-08
+
+* **Enhanced:** Task names on the Today page now link to the task editor and display the associated client.
+
 ## 1.9.1 - 2025-08-08
 
 * **Fix**: Updated the "User Data Isolation" self-test to align with the new rule that only shows tasks to the assignee.

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.9.0
+ * Version:           1.9.3
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.9.0' );
+define( 'PTT_VERSION', '1.9.3' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -488,6 +488,9 @@ function ptt_activate_kanban_additions() {
  * Enqueues scripts and styles for admin and front-end.
  */
 function ptt_enqueue_assets() {
+    // Google Font for timer displays
+    wp_enqueue_style( 'ptt-font-silkscreen', 'https://fonts.googleapis.com/css2?family=Silkscreen&display=swap', [], null );
+
     // Main CSS file (now in root)
     wp_enqueue_style( 'ptt-styles', PTT_PLUGIN_URL . 'styles.css', [], PTT_VERSION );
 

--- a/styles.css
+++ b/styles.css
@@ -915,7 +915,7 @@
 }
 
 #ptt-today-page-container .ptt-today-timer-display {
-    font-family: monospace, sans-serif;
+    font-family: 'Silkscreen', monospace, sans-serif;
     font-size: 28px;
     font-weight: bold;
     color: #1d2327;
@@ -990,9 +990,13 @@
 }
 
 #ptt-today-page-container .entry-duration {
-    font-family: monospace, sans-serif;
+    font-family: 'Silkscreen', monospace, sans-serif;
     font-size: 16px;
     font-weight: bold;
+}
+
+#ptt-today-page-container #ptt-today-total strong {
+    font-family: 'Silkscreen', monospace, sans-serif;
 }
 
 #ptt-today-page-container .ptt-today-entry.running .entry-duration {

--- a/today.php
+++ b/today.php
@@ -297,18 +297,23 @@ function ptt_get_daily_entries_callback() {
 						}
 						$grand_total_seconds += $duration_seconds;
 
-						$project_terms = get_the_terms( $post_id, 'project' );
-						$project_name  = ! is_wp_error( $project_terms ) && $project_terms ? $project_terms[0]->name : '–';
+                                               $project_terms = get_the_terms( $post_id, 'project' );
+                                               $project_name  = ! is_wp_error( $project_terms ) && $project_terms ? $project_terms[0]->name : '–';
 
-						$all_entries[] = [
-							'session_title'  => $session['session_title'],
-							'task_title'     => get_the_title(),
-							'project_name'   => $project_name,
-							'start_time'     => $start_ts,
-							'stop_time'      => $stop_ts, // Added stop_time
-							'duration'       => $duration_seconds > 0 ? gmdate( 'H:i:s', $duration_seconds ) : 'Running',
-							'is_running'     => empty( $stop_str ),
-						];
+                                               $client_terms = get_the_terms( $post_id, 'client' );
+                                               $client_name  = ! is_wp_error( $client_terms ) && $client_terms ? $client_terms[0]->name : '–';
+
+                                               $all_entries[] = [
+                                                       'session_title' => $session['session_title'],
+                                                       'task_title'    => get_the_title(),
+                                                       'task_id'       => $post_id,
+                                                       'project_name'  => $project_name,
+                                                       'client_name'   => $client_name,
+                                                       'start_time'    => $start_ts,
+                                                       'stop_time'     => $stop_ts, // Added stop_time
+                                                       'duration'      => $duration_seconds > 0 ? gmdate( 'H:i:s', $duration_seconds ) : 'Running',
+                                                       'is_running'    => empty( $stop_str ),
+                                               ];
 					}
 				}
 			}
@@ -329,12 +334,13 @@ function ptt_get_daily_entries_callback() {
 		foreach ( $all_entries as $entry ) {
 			$running_class = $entry['is_running'] ? 'running' : '';
 			?>
-			<div class="ptt-today-entry <?php echo $running_class; ?>">
-				<div class="entry-details">
-					<span class="entry-session-title"><?php echo esc_html( $entry['session_title'] ); ?></span>
-					<span class="entry-meta"><?php echo esc_html( $entry['task_title'] ); ?> &bull; <?php echo esc_html( $entry['project_name'] ); ?></span>
-				</div>
-				<div class="entry-duration">
+                               <div class="ptt-today-entry <?php echo $running_class; ?>">
+                               <div class="entry-details">
+                                       <span class="entry-session-title"><?php echo esc_html( $entry['session_title'] ); ?></span>
+                                       <?php $edit_link = get_edit_post_link( $entry['task_id'] ); ?>
+                                       <span class="entry-meta"><a href="<?php echo esc_url( $edit_link ); ?>"><?php echo esc_html( $entry['task_title'] ); ?></a> &bull; <?php echo esc_html( $entry['project_name'] ); ?> &bull; <?php echo esc_html( $entry['client_name'] ); ?></span>
+                               </div>
+                               <div class="entry-duration">
 					<?php echo esc_html( wp_date( 'g:i:s A', $entry['start_time'] ) ); ?> |
 					<?php echo $entry['is_running'] ? 'Now' : esc_html( wp_date( 'g:i:s A', $entry['stop_time'] ) ); ?> |
 					SUB-TOTAL: <?php echo esc_html( $entry['duration'] ); ?>


### PR DESCRIPTION
## Summary
- Link each task name on the Today page to its task editor and display associated client
- Load Silkscreen Google font and apply it to timer and duration displays on the Today page
- Bump plugin version to 1.9.3 and document the change

## Testing
- `php self-test.php`
- `php -l project-task-tracker.php`
- `php -l today.php`


------
https://chatgpt.com/codex/tasks/task_b_689767417518832eaedb88f8a0ee6fc6