### PR TITLE
Refactor Today page entry rendering for future AJAX editing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "KISS - Project & Task Time Tracker" plugin will be documented in this file.
 
+## 1.9.2 - 2025-08-09
+
+* **Refactor**: Today page now returns structured entry data for flexible AJAX rendering.
+
 ## 1.9.1 - 2025-08-08
 
 * **Fix**: Updated the "User Data Isolation" self-test to align with the new rule that only shows tasks to the assignee.

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.9.0
+ * Version:           1.9.2
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.9.0' );
+define( 'PTT_VERSION', '1.9.2' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/scripts.js
+++ b/scripts.js
@@ -1003,8 +1003,19 @@ jQuery(document).ready(function ($) {
         const $dateSelect = $('#ptt-today-date-select');
         const $entriesList = $('#ptt-today-entries-list');
         const $totalDisplay = $('#ptt-today-total strong');
-        
+
         let activeTimerInterval = null;
+
+        function renderTodayEntry(entry) {
+            const runningClass = entry.is_running ? 'running' : '';
+            return `<div class="ptt-today-entry ${runningClass}">
+                <div class="entry-details">
+                    <span class="entry-session-title">${entry.session_title}</span>
+                    <span class="entry-meta"><a href="${entry.edit_link}" target="_blank">${entry.task_title}</a> &bull; ${entry.project_name}</span>
+                </div>
+                <div class="entry-duration">${entry.start_time} | ${entry.is_running ? 'Now' : entry.stop_time} | SUB-TOTAL: ${entry.duration}</div>
+            </div>`;
+        }
 
         // Fetch tasks when project filter changes
         $projectFilter.on('change', function() {
@@ -1112,7 +1123,15 @@ jQuery(document).ready(function ($) {
                 date: selectedDate
             }).done(function(response){
                 if (response.success) {
-                    $entriesList.html(response.data.html);
+                    const entries = response.data.entries || [];
+                    $entriesList.empty();
+                    if (entries.length) {
+                        entries.forEach(entry => {
+                            $entriesList.append(renderTodayEntry(entry));
+                        });
+                    } else {
+                        $entriesList.html('<div class="ptt-today-no-entries">No time entries recorded for this day.</div>');
+                    }
                     $totalDisplay.text(response.data.total);
                     // Update debug info
                     if (response.data.debug) {


### PR DESCRIPTION
## Summary
- expose structured entry data from Today page AJAX handler and add reusable entry renderer
- render Today page rows client-side for easier live updates
- bump plugin to v1.9.2 with changelog

## Testing
- `php -l today.php`
- `php -l project-task-tracker.php`
- `node --check scripts.js`
- `php self-test.php`

------
https://chatgpt.com/codex/tasks/task_b_68976f4099c8832ea04399e02fa2ef81