### PR TITLE
Implement session reassignment logic with self-test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 1.10.3 - Session Reassignment Logic
+*Release Date: TBD*
+
+### Added
+- Backend function and AJAX handler to move a work session between tasks.
+- Self-test coverage for session reassignment.
+
 ## Version 1.10.2 - Today Page Refinements
 *Release Date: TBD*
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.10.2
+ * Version:           1.10.3
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.10.2' );
+define( 'PTT_VERSION', '1.10.3' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
## Summary
- add helper and AJAX endpoint to move a session between tasks
- cover session reassignment with new self-test
- bump plugin version to 1.10.3 and update changelog

## Testing
- `php -l today.php`
- `php -l project-task-tracker.php`
- `php -l self-test.php`


------
https://chatgpt.com/codex/tasks/task_b_6897ebba2658832ead8c358f7910544e