### PR TITLE
low-risk service wiring and start-timer integration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,51 +8,71 @@
 - [ ] Human QA Testing - Not done yet
 
 
-## Phase 2 – Convert Remaining Modules (In Progress)
-- [ ] Establish service seams under PSR-4
-  - [ ] src/Support/Services locator
-  - [ ] src/Integration/ACF/ACFAdapter
-  - [ ] src/Domain/Session/SessionRepository
-  - [ ] src/Presentation/Today/TodayService
-- [ ] Migrate Today page data/renderer into classes (use TodayService)
-- [ ] Migrate Reports into classes
-- [ ] Centralize AJAX callbacks in Plugin::init via namespaced callables
+## Phase 2 – Core Domain & Storage (High Priority)
+- [ ] CPT & Taxonomy audit (Core)
+  - [ ] Confirm project_task args/capabilities; map custom capabilities if needed
+  - [ ] Verify taxonomy bindings (client, project, task_status) and UI visibility
+- [ ] ACF Field schema hardening (Core)
+  - [ ] Lock field keys/types for: sessions repeater (session_start_time, session_stop_time, session_manual_override, session_manual_duration, session_title, session_notes)
+  - [ ] Parent-level fields (start_time, stop_time, manual_override, manual_duration), calculated_duration
+  - [ ] Document key->name mapping; add migration notes if any keys change
+  - [x] Create ACFAdapter (src/Integration/ACF/ACFAdapter.php)
+  - [x] Create SessionRepository (src/Domain/Session/SessionRepository.php)
+  - [x] Create TimerService skeleton (src/Domain/Timer/TimerService.php)
 
-## Phase 3 – Finalize PSR-4 Migration (In Progress)
-- [ ] Remove legacy wrappers and global functions after services are adopted
-- [ ] Consolidate hook registration in Plugin::boot
-- [ ] Add comprehensive tests for new class architecture
+- [ ] Session Domain & Repository (Core)
+  - [ ] src/Domain/Session/SessionRepository (minimal-read access; avoid full repeater hydration)
+  - [ ] Invariants: one active session per user; prevent overlaps; deterministic ordering
+  - [ ] Time normalization (UTC) and rounding rules in one place
+- Decision (low‑risk for finish line): Register services directly on Plugin; defer Service Locator to Post‑Project
 
-## Phase 4 – ACF Performance and Reliability (Phase A)
-- [ ] Use minimal-read patterns for Today (avoid full repeater hydration)
-- [ ] Introduce per-row session_uuid and update-by-UUID semantics
-- [ ] 60s cache for TodayService; invalidate on acf/save_post of affected tasks
-- [ ] Manual-override precedence and UTC normalization in the domain layer
-- [ ] Instrument timings of get_field/update_field and track improvements
+- [ ] Timer Orchestration (Core)
+  - [ ] src/Domain/Timer/TimerService for start/stop/resume transitions and validation
+  - [ ] Hooks for auditing: ptt_session_started/updated/stopped
+  - [x] Wire ACFAdapter/SessionRepository/TimerService directly on Plugin (low‑risk)
+  - [x] Route start‑timer flow through TimerService
 
-## Phase 5 – Session Storage Promotion (Decision Point)
+
+## Phase 3 – Service Seams under PSR‑4 (In Progress)
+- [ ] src/Support/Services locator
+- [ ] src/Integration/ACF/ACFAdapter (field‑key access, UTC conversions)
+- [ ] Wire repositories/services in Plugin::init/boot
+
+## Phase 4 – Session Storage Promotion (Decision Point)
 Option B1 – Session CPT (ptt_session)
 - [ ] Register CPT and link to task (parent/meta); add indexes
 - [ ] Migration tool: ACF repeater rows -> CPT posts
-- [ ] Swap SessionRepository to CPT queries; update TodayService
+- [ ] Swap SessionRepository to CPT queries; update services
 - [ ] Expose REST for CPT; permissions and capability mapping
 
 Option B2 – Custom table (wp_ptt_sessions)
 - [ ] Table schema and install/upgrade routine
 - [ ] Repository CRUD + indexed queries
 - [ ] Migration tool from ACF repeater
-- [ ] Update TodayService to use table queries
+- [ ] Update services to use table queries
 
-## Phase 6 – Public API and Extensibility
+## Phase 5 – ACF Performance and Reliability (Phase A)
+- [ ] Minimal-read patterns for ACF (avoid full repeater hydration)
+- [ ] Introduce per-row session_uuid and update-by-UUID semantics
+- [ ] 60s cache for TodayService; invalidate on acf/save_post of affected tasks
+- [ ] Manual-override precedence and UTC normalization in the domain layer
+- [ ] Instrument timings of get_field/update_field and track improvements
+
+## Phase 6 – Today UI and Controllers (Lower Priority)
+- [ ] Migrate Today page data/renderer into classes (Presentation\Today)
+- [ ] Centralize AJAX callbacks in Plugin::init via namespaced callables
+- [ ] Replace procedural handlers with service calls; defer UI polish to later
+
+## Phase 7 – Public API and Extensibility
 - [ ] Enable show_in_rest for CPT/taxonomies (read-only), or
 - [ ] Register curated REST endpoints under /ptt/v1 for session/task operations
 - [ ] Add extension hooks (actions/filters): ptt_session_saved, ptt_today_entries_built
 
-## Phase 7 – QA, Testing, and Metrics (Ongoing)
-- [ ] PHPUnit setup; unit tests for SessionRepository and TodayService
-- [ ] E2E smoke tests for key AJAX flows (start/stop, Today load)
-- [ ] Performance budgets; track Today page render and session CRUD latency
+## Phase 8 – QA, Testing, and Metrics (Ongoing)
+- [ ] PHPUnit setup; unit tests for SessionRepository/TimerService and TodayService
+- [ ] E2E smoke tests for key flows (start/stop, Today load)
+- [ ] Performance budgets; track Today render and session CRUD latency
 
 ### Sequencing Notes
-- Finish the minimal PSR-4 seams in Phase 2, then start Phase 4 immediately; you do not need to finish all of Phase 3 first.
-- Centralizing ACF access behind SessionRepository/ACFAdapter makes Phase 5 (CPT or table) a drop-in change later.
+- Focus Phase 2 (Core Domain & Storage) first; Today UI is intentionally deferred to Phase 6.
+- Centralizing ACF access behind SessionRepository/ACFAdapter makes Phase 4 (CPT or table) a drop‑in change later.

--- a/src/Domain/Session/SessionRepository.php
+++ b/src/Domain/Session/SessionRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace KISS\PTT\Domain\Session;
+
+use KISS\PTT\Integration\ACF\ACFAdapter;
+
+/**
+ * Repository for reading/writing task sessions stored in ACF repeater fields.
+ * This is a minimal-read access layer to avoid full repeater hydration.
+ */
+class SessionRepository
+{
+    public const REPEATER = 'sessions';
+
+    private ACFAdapter $acf;
+
+    public function __construct(ACFAdapter $acf)
+    {
+        $this->acf = $acf;
+    }
+
+    /** Get all sessions for a task (full read). Prefer targeted helpers when possible. */
+    public function getAll(int $postId): array
+    {
+        $sessions = $this->acf->getField(self::REPEATER, $postId);
+        return is_array($sessions) ? $sessions : [];
+    }
+
+    /** Count of sessions for bounds checks. */
+    public function count(int $postId): int
+    {
+        $sessions = $this->acf->getField(self::REPEATER, $postId);
+        return is_array($sessions) ? count($sessions) : 0;
+    }
+
+    /** Add a new session row. Returns true on success. */
+    public function add(array $row, int $postId): bool
+    {
+        return $this->acf->addRow(self::REPEATER, $row, $postId);
+    }
+
+    /** Update a sub field for a session row (0-based index -> ACF 1-based). */
+    public function updateSub(int $index0, string $fieldName, $value, int $postId): bool
+    {
+        $selector = [ self::REPEATER, $index0 + 1, $fieldName ];
+        return $this->acf->updateSubField($selector, $value, $postId);
+    }
+
+    /** Delete a session row by 0-based index. */
+    public function delete(int $index0, int $postId): bool
+    {
+        return $this->acf->deleteRow(self::REPEATER, $index0 + 1, $postId);
+    }
+}
+

--- a/src/Domain/Timer/TimerService.php
+++ b/src/Domain/Timer/TimerService.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace KISS\PTT\Domain\Timer;
+
+use KISS\PTT\Integration\ACF\ACFAdapter;
+use KISS\PTT\Domain\Session\SessionRepository;
+
+/**
+ * Timer orchestration: start/stop/resume with validation.
+ * This is a thin domain layer; handlers/controllers should call into this.
+ */
+class TimerService
+{
+    private ACFAdapter $acf;
+    private SessionRepository $sessions;
+
+    public function __construct(ACFAdapter $acf, SessionRepository $sessions)
+    {
+        $this->acf = $acf;
+        $this->sessions = $sessions;
+    }
+
+    /** Start a new session on a task with an initial title. */
+    public function start(int $postId, string $title): bool
+    {
+        // Basic invariant: no overlapping parent-level timer on this task
+        $start = $this->acf->getField('start_time', $postId);
+        $stop  = $this->acf->getField('stop_time', $postId);
+        if ($start && !$stop) {
+            return false;
+        }
+
+        $now = $this->acf->nowUtc();
+        $row = [
+            'session_title'           => $title,
+            'session_start_time'      => $now,
+            'session_stop_time'       => '',
+            'session_manual_override' => 0,
+            'session_manual_duration' => 0,
+        ];
+        return $this->sessions->add($row, $postId);
+    }
+
+    /** Stop the active (running) session for a task, if any. */
+    public function stopActive(int $postId): bool
+    {
+        $count = $this->sessions->count($postId);
+        if ($count <= 0) { return false; }
+        $now = $this->acf->nowUtc();
+        // Walk backward for running session
+        $sessions = $this->sessions->getAll($postId);
+        for ($i = $count - 1; $i >= 0; $i--) {
+            $s = $sessions[$i] ?? [];
+            if (!empty($s['session_start_time']) && empty($s['session_stop_time'])) {
+                return $this->sessions->updateSub($i, 'session_stop_time', $now, $postId);
+            }
+        }
+        return false;
+    }
+}
+

--- a/src/Integration/ACF/ACFAdapter.php
+++ b/src/Integration/ACF/ACFAdapter.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace KISS\PTT\Integration\ACF;
+
+use DateTime;
+use DateTimeZone;
+
+/**
+ * Thin wrapper around ACF functions to centralize access and UTC normalization.
+ * NOTE: This adapter assumes ACF functions exist; callers should guard in environments
+ * where ACF is not loaded.
+ */
+class ACFAdapter
+{
+    /** Get field value by name for a post. */
+    public function getField(string $name, int $postId)
+    {
+        return function_exists('get_field') ? get_field($name, $postId) : null;
+    }
+
+    /** Update field value by name for a post. */
+    public function updateField(string $name, $value, int $postId): bool
+    {
+        return function_exists('update_field') ? (bool) update_field($name, $value, $postId) : false;
+    }
+
+    /** Add a row to a repeater field. */
+    public function addRow(string $repeaterName, array $row, int $postId): bool
+    {
+        return function_exists('add_row') ? (bool) add_row($repeaterName, $row, $postId) : false;
+    }
+
+    /** Update a sub field within a repeater field. Index is 1-based for ACF. */
+    public function updateSubField(array $selector, $value, int $postId): bool
+    {
+        return function_exists('update_sub_field') ? (bool) update_sub_field($selector, $value, $postId) : false;
+    }
+
+    /** Delete a row from a repeater field by 1-based index. */
+    public function deleteRow(string $repeaterName, int $index1Based, int $postId): bool
+    {
+        return function_exists('delete_row') ? (bool) delete_row($repeaterName, $index1Based, $postId) : false;
+    }
+
+    /**
+     * Normalize a MySQL datetime string to UTC (Y-m-d H:i:s) if possible.
+     * Accepts values already in UTC; returns original if parsing fails.
+     */
+    public function normalizeUtc(?string $mysqlDateTime): ?string
+    {
+        if (!$mysqlDateTime) { return $mysqlDateTime; }
+        try {
+            $dt = new DateTime($mysqlDateTime, new DateTimeZone('UTC'));
+            return $dt->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d H:i:s');
+        } catch (\Throwable $e) {
+            return $mysqlDateTime;
+        }
+    }
+
+    /** Current UTC now in MySQL format. */
+    public function nowUtc(): string
+    {
+        return (new DateTime('now', new DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+    }
+}
+

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,9 +2,24 @@
 namespace KISS\PTT;
 
 use KISS\PTT\Time\Calculator;
+use KISS\PTT\Integration\ACF\ACFAdapter;
+use KISS\PTT\Domain\Session\SessionRepository;
+use KISS\PTT\Domain\Timer\TimerService;
 
 class Plugin {
+    // Simple, low-risk: register services directly on Plugin
+    public static ACFAdapter $acf;
+    public static SessionRepository $sessions;
+    public static TimerService $timer;
+
+
     public static function init() {
+        // Instantiate services (low risk)
+        self::$acf      = new ACFAdapter();
+        self::$sessions = new SessionRepository( self::$acf );
+        self::$timer    = new TimerService( self::$acf, self::$sessions );
+
+
         self::register_hooks();
         // Load remaining procedural modules
         require_once PTT_PLUGIN_DIR . 'helpers.php';


### PR DESCRIPTION
Wired services directly on Plugin (low risk)
Added static instances on KISS\PTT\Plugin:
ACFAdapter
SessionRepository
TimerService
Instantiated them in Plugin::init() before loading procedural modules Routed start timer through TimerService
Updated ptt_today_start_timer_callback to call Plugin::$timer->start($post_id, $session_title) Preserved display-time title logic and subsequent recalculation If a conflicting parent-level timer exists on the task, the service returns false and the handler returns a JSON error

New core classes
src/Integration/ACF/ACFAdapter.php
src/Domain/Session/SessionRepository.php
src/Domain/Timer/TimerService.php