### PR TITLE
Hide public Task post content and redirect logged-in users to editor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 
 
+## Version 1.12.7 - Hide front-end Task content
+
+- Tasks CPT posts are no longer publicly viewable
+  - Logged-in users are redirected to the post editor when visiting a Task URL
+  - Non-logged-in visitors receive a 404 response
+
 ## Version 1.12.6 - All Tasks page assignee sorting and filtering
 
 - All Tasks page

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 
 
+## Version 1.12.8 - Preserve Task permalinks
+
+- Restored public registration so Task permalinks remain accessible
+- Front-end requests still redirect logged-in editors to wp-admin and serve 404s to visitors
+
 ## Version 1.12.7 - Hide front-end Task content
 
 - Tasks CPT posts are no longer publicly viewable

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           1.12.7
+ * Version:           1.12.8
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '1.12.7' );
+define( 'PTT_VERSION', '1.12.8' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -123,7 +123,7 @@ function ptt_register_post_type() {
 
     $args = [
         'labels'             => $labels,
-        'public'             => false,
+        'public'             => true,
         'publicly_queryable' => true,
         'show_ui'            => true,
         'show_in_menu'       => true,


### PR DESCRIPTION
## Summary
- make Task posts non-public and exclude them from search
- redirect logged-in users who view Task links to the post editor and serve 404s to others
- bump version to 1.12.7 and document change

## Testing
- `php self-test.php` *(fails: requires WordPress environment)*
- `php -l project-task-tracker.php`


------
https://chatgpt.com/codex/tasks/task_b_68a8af6a9628832ea665dcf0f826e02d