### PR TITLE
Psr4 fix all tasks assignee filters sorting - Version 2.2.31

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,70 +1,44 @@
+## Priority Plan (PSR‑4 → TypeScript → FSM)
+
+- PSR‑4 (one more pass — best bang for buck)
+  - [ ] Migrate Reports to PSR‑4 (Presentation\Reports: Controller/Service)
+  - [ ] Fix Reports date‑range UTC normalization during the move
+  - [ ] Register TodayController::register() from Plugin::init (avoid double hooks with compat)
+  - [ ] Optional: Add deprecation flag for today‑helpers‑compat wrappers (log _doing_it_wrong when enabled)
+
+- TypeScript (Today page pilot — highest UX/stability ROI)
+  - [ ] Add minimal build (esbuild or Vite) with strict tsconfig
+  - [ ] Define types: Entry, Session, TimerAction; typed fetch/AJAX client
+  - [ ] Implement typed modules: start/stop/resume controls; move‑session flow; inline duration editing
+  - [ ] Scope bundle to Today admin page; graceful fallback; add a few Vitest tests
+
+- FSM (after TS pilot)
+  - [ ] Integrate TimerFSM with typed controls behind a feature flag
+  - [ ] Add lightweight metrics/logging for state transitions
+  - [ ] Plan DataFSM next (read model, cache invalidation)
+
+
 # Roadmap
 
 ## Human QA Testing
-Missing: A comprehensive end-to-end test that simulates real user workflow.
-
-My Thoughts on Your "Special 15 Minute End to End Test" Idea
-This is an excellent idea for several reasons:
-
-Real-world validation - Tests the actual user journey, not just isolated functions
-User confidence - Gives users a way to verify everything works before using it for real work
-Debugging aid - When users report issues, you can ask them to run this test first
-Demo functionality - New users can see how the plugin works without creating real data
-Regression testing - After updates, users can quickly verify nothing broke
-Proposed Implementation
-I suggest creating a "Demo & Test" page that:
-
-Opens in a new tab (as you suggested) to avoid disrupting their current work
-Creates temporary demo data with clear naming (e.g., "DEMO - Client ABC", "DEMO - Project XYZ")
-Walks through the complete workflow:
-Create a client
-Create a project under that client
-Create a task under that project
-Start a timer session
-Stop the timer after a few seconds
-Show the results on the Today page
-Provides step-by-step feedback showing what's happening
-Cleans up after itself (with user confirmation)
-Includes a "Skip to Results" option for quick validation
-Would you like me to implement this "15 Minute End to End Test" page? I can:
-
-Create a new admin page accessible from the Tasks menu
-Build an interactive test that guides users through the complete workflow
-Make it open in a new tab as you suggested
-Include real-time progress indicators and validation
-Add cleanup functionality to remove demo data when done
-This would complement the existing self-tests perfectly - the current tests validate the technical foundation, while this new test would validate the user experience.
+- [ ] 15 Minute E2E Demo/Test page (Deferred ~1 week)
+  - [ ] Opens in a new tab; creates demo data; cleans up after confirmation
+  - [ ] Walkthrough: client → project → task → start/stop → verify Today page
+  - [ ] Step-by-step feedback and a Skip-to-Results option
 
 ## NEXT MAJOR PROJECT: FSM
-
-- Objective: Introduce a Finite State Machine (FSM) architecture for the Today page to improve reliability, debuggability, and code clarity.
-- Plan: See PROJECT-FSM.md for the phased, actionable checklist (TimerFSM + DataFSM, controller, effects, rollout plan).
-- Status: Planning complete; next step is Phase 0 (Preparation) and Phase 1 (TimerFSM pilot behind feature flag).
+- [ ] Introduce Today page FSM to improve reliability and debuggability
+- [ ] See PROJECT-FSM.md for detailed phases (TimerFSM + DataFSM, controller/effects)
+- [ ] Next: Phase 0 prep and Phase 1 pilot behind a feature flag
 
 
 ## Near‑Term Priorities (August 2025)
-
-1) Ship two targeted bug fixes before further PSR‑4 work
-   - Reports → Classic: date‑range filtering can miss expected rows due to UTC/local parsing of session_start_time. Fix by normalizing to UTC during comparisons.
-   - Today → Quick Start: duplicate entries appear because the page shows a task‑level "created" entry and a session entry on the same day. Suppress the task‑level entry when a same‑day session exists.
-
-2) Resume incremental PSR‑4 tasks after the fixes
-   - Keep Plugin as the simple service container for now.
-   - Add UTC/date helpers to ACFAdapter and route reporting/TODAY comparisons through those (no UI refactor).
-
-3) QA/User Validation Enhancements
-   - Deferred ~1 week: Implement the "15 Minute End‑to‑End Test" Demo page that opens in a new tab and cleans up after itself (preferred workflow test).
-   - Add a quick admin command/button to run Self‑Tests and display results inline, with a link to detailed logs.
-
-4) PSR‑4 Hardening for Today Helpers
-   - [x] Split TodayHelpers classes (EntryRenderer, DataProvider, PageManager) into separate files to align with Composer’s PSR‑4 expectations and remove explicit requires.
-   - [x] Retired explicit include in Plugin::init; Composer autoload now loads classes.
-   - [x] Removed the TodayHelpers placeholder class/file.
-   - [ ] Consider deprecating today-helpers-compat.php wrappers (add notices behind a flag) once plugin usage migrates to PSR‑4 everywhere.
-
-5) Compatibility & Hooks
-   - Call TodayController::register() directly from Plugin::init; gradually retire today-compat hook registrations.
-   - Keep legacy wrappers for a deprecation window and add _doing_it_wrong() notices behind a flag.
+- [ ] Reports: Fix date‑range UTC normalization (best bang for buck)
+- [ ] Reports: Migrate to PSR‑4 (Controller/Service), apply the fix during migration
+- [ ] Today: Call TodayController::register() from Plugin::init (avoid double hooks)
+- [ ] Optional: Deprecation flag for today‑helpers‑compat wrappers
+- [ ] QA: Quick admin action to run Self‑Tests and show results inline
+- [ ] QA: 15 Minute E2E Demo/Test page (Deferred ~1 week)
 
 Notes on FSM and PSR‑4
 - The Today‑page FSM (TimerFSM/DataFSM) is an independent UI/controller improvement. It is not required to ship the two bug fixes above.
@@ -79,7 +53,7 @@ Notes on FSM and PSR‑4
 - [x] Move time calculation logic into `KISS\PTT\Time\Calculator`
 - [x] Wrap existing helper functions to call namespaced classes
 - [x] Self-Tests suite stabilized (67/67 passing)
-- [ ] Human QA Testing (End‑to‑End): Provide "15 Minute E2E Test" page that opens in a new tab and cleans up after itself (Deferred ~1 week)
+- [ ] Human QA Testing (15 Minute E2E Demo/Test page) — Deferred ~1 week
 
 
 ## Phase 2 – Core Domain & Storage (High Priority)

--- a/assets/js/fsm/timer/EditorEffects.js
+++ b/assets/js/fsm/timer/EditorEffects.js
@@ -13,8 +13,17 @@
     // Find first session row without a start time; fallback to index 0
     var $rows = jQuery('.acf-field[data-key="field_ptt_sessions"] .acf-row');
     var index = 0;
-    $rows.each(function(i){ var v = jQuery(this).find('[data-key="field_ptt_session_start_time"] input').val(); if(!v){ index = i; return false; } });
-    return ajax('ptt_start_session_timer', { post_id: taskId, row_index: index });
+    var title = '';
+    $rows.each(function(i){
+      var $row = jQuery(this);
+      var v = $row.find('[data-key="field_ptt_session_start_time"] input').val();
+      if(!v){ index = i; title = ($row.find('[data-key="field_ptt_session_title"] input').val()||'').trim(); return false; }
+    });
+    return ajax('ptt_start_session_timer', { post_id: taskId, row_index: index, session_title: title })
+      .then(function(data){
+        // Normalize result for FSM: { startUtc, postId, sessionIndex }
+        return { startUtc: data.start_time, postId: taskId, sessionIndex: (typeof data.row_index!=='undefined'? data.row_index : index) };
+      });
   };
   EditorEffects.prototype.stopTimer  = function(postId){
     // Determine index from visible running row
@@ -24,11 +33,21 @@
     return ajax('ptt_stop_session_timer', { post_id: postId, row_index: index });
   };
   EditorEffects.prototype.rehydrate  = function(){
-    // If a row has start and no stop, consider running
-    var $rows = jQuery('.acf-field[data-key="field_ptt_sessions"] .acf-row');
-    var running = false, postId = jQuery('#post_ID').val()||null, sessionIndex = null, startUtc=null;
-    $rows.each(function(i){ var s = jQuery(this).find('[data-key="field_ptt_session_start_time"] input').val(); var e = jQuery(this).find('[data-key="field_ptt_session_stop_time"] input').val(); if(s && !e){ running=true; sessionIndex=i; startUtc=s; return false; } });
-    return Promise.resolve(running ? { running:true, postId:postId, sessionIndex:sessionIndex, startUtc:startUtc } : { running:false });
+    // Ask server for user's active session; only activate if it's this post
+    var postId = jQuery('#post_ID').val()||null;
+    return new Promise(function(resolve){
+      jQuery.post((root.ptt_ajax_object && root.ptt_ajax_object.ajax_url)||'', {
+        action: 'ptt_get_active_session_for_user', nonce: (root.ptt_ajax_object && root.ptt_ajax_object.nonce)||''
+      }).done(function(resp){
+        if(resp && resp.success && resp.data){
+          if(resp.data.running && postId && parseInt(resp.data.post_id,10)===parseInt(postId,10)){
+            resolve({ running:true, postId: resp.data.post_id, sessionIndex: resp.data.session_index, startUtc: resp.data.start_time });
+            return;
+          }
+        }
+        resolve({ running:false });
+      }).fail(function(){ resolve({ running:false }); });
+    });
   };
   EditorEffects.prototype.updateTimerUI = function(state, ctx){
     var $rows = jQuery('.acf-field[data-key="field_ptt_sessions"] .acf-row');

--- a/assets/js/fsm/timer/EditorTimerController.js
+++ b/assets/js/fsm/timer/EditorTimerController.js
@@ -33,8 +33,11 @@
     }
 
     fsm.rehydrate();
-    jQuery(document).on('click', '.ptt-session-start', function(e){ e.preventDefault(); var postId = jQuery('#post_ID').val(); fsm.transition('START_TIMER', { taskId: postId }); });
-    jQuery(document).on('click', '.ptt-session-stop', function(e){ e.preventDefault(); fsm.transition('STOP_TIMER'); });
+    // When FSM is enabled, intercept editor start/stop and route through FSM
+    jQuery(document).off('click.pttEditorStart');
+    jQuery(document).off('click.pttEditorStop');
+    jQuery(document).on('click.pttEditorStart', '.ptt-session-start', function(e){ e.preventDefault(); var postId = jQuery('#post_ID').val(); fsm.transition('START_TIMER', { taskId: postId }); });
+    jQuery(document).on('click.pttEditorStop', '.ptt-session-stop', function(e){ e.preventDefault(); fsm.transition('STOP_TIMER'); });
     root.PTT_EditorFSM = fsm;
   }
   if(document.readyState==='loading'){ document.addEventListener('DOMContentLoaded', init); } else { init(); }

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+
+## Version 2.2.31 - Reinforce Update button visibility on Task Editor
+- Added robust insertion of an "Update" button next to the Sessions repeater "Add Session" button.
+- Uses MutationObserver + periodic retries to ensure the button is present even if ACF renders late.
+- Styled as a primary button and placed inline with "Add Session" so it’s easy to find.
+- Clicking it triggers the main Publish/Update action (#publish) with disabled state and feedback.
+
+## Version 2.2.30 - Total Duration: add friendly hh:mm display
+- **Added**: On the Task Editor, next to Total Duration (hrs), show a friendly hh:mm equivalent (read-only badge) that updates live as the value changes.
+- **Note**: All calculations remain decimal hours; hh:mm is display-only for user friendliness.
+
 ## Version 2.2.29 - Preserve historical manual sessions; disable auto-timestamp on save
 - **Changed**: Manual session entries without start/stop timestamps are no longer auto-stamped on save. This prevents older manual entries from being pulled into the current day when a new timer is stopped.
 - **Updated**: Self-tests adjusted to verify that manual sessions without timestamps remain unchanged.

--- a/changelog.md
+++ b/changelog.md
@@ -151,6 +151,13 @@
 
 ## Version 2.2.13 - Today page duplicate entries fix
 
+
+## Version 2.2.33 - All Tasks: Assignee sorting/filter restored + self-test
+Released: 2025-08-26
+- Restored Assignee column sorting (ASC/DESC) on All Tasks admin list
+- Added Assignee filter dropdown to narrow rows by user
+- Added automated self-test to verify sortable column registration and dropdown rendering
+
 ## Version 2.2.32 - FSM-centric timer persistence + UI polish
 Released: 2025-08-26
 - Editor: Start Timer is now routed via FSM EditorEffects/Controller when FSM is enabled, ensuring a single authoritative state machine controls timers.

--- a/changelog.md
+++ b/changelog.md
@@ -150,6 +150,18 @@
 **Note**: This migration is one-way. Once completed, you cannot revert to parent-level timer fields without restoring from a database backup.
 
 ## Version 2.2.13 - Today page duplicate entries fix
+
+## Version 2.2.32 - FSM-centric timer persistence + UI polish
+Released: 2025-08-26
+- Editor: Start Timer is now routed via FSM EditorEffects/Controller when FSM is enabled, ensuring a single authoritative state machine controls timers.
+- Server: ptt_start_session_timer now creates the session row server-side if the requested index doesn't exist and returns the authoritative row_index.
+- Editor: Start handler sends session_title; on mismatch row_index, the UI reloads to sync with the database.
+- Editor: Added ptt_get_active_session_for_user endpoint and FSM rehydrate implementation to recover running session after reload.
+- Editor: Disabled Start Timer when Manual Override is checked for the session.
+- UI: Align hh:mm badge inline with Total Duration input; responsive layout on small screens.
+- Safety: Added onbeforeunload guard for 2–3 seconds after Start to reduce accidental navigation before save completes.
+- Version bump and changelog updated.
+
 - Fixed Today page showing duplicate entries for Quick Start tasks (both "created" and session entries on same day).
 - Added logic to suppress task-level "created" entries when session entries exist for the same date.
 

--- a/legacy-core.php
+++ b/legacy-core.php
@@ -413,12 +413,40 @@ function ptt_start_session_timer_callback() {
         ptt_stop_session( $post_id, $active );
     }
 
-    $current_time = current_time( 'mysql', 1 ); // Use UTC time
-    update_sub_field( array( 'sessions', $row_index + 1, 'session_start_time' ), $current_time, $post_id );
-    update_sub_field( array( 'sessions', $row_index + 1, 'session_stop_time' ), '', $post_id );
-    update_sub_field( array( 'sessions', $row_index + 1, 'session_calculated_duration' ), '0.00', $post_id );
+    $current_time   = current_time( 'mysql', 1 ); // UTC
+    $session_title  = isset($_POST['session_title']) ? sanitize_text_field( wp_unslash($_POST['session_title']) ) : '';
+    if ( $session_title === '' ) { $session_title = 'Session ' . date_i18n( 'g:i A' ); }
 
-    wp_send_json_success( [ 'message' => 'Session started!', 'start_time' => $current_time ] );
+    // Ensure the requested row exists; if not, append a new one server-side
+    $sessions = get_field( 'sessions', $post_id );
+    $count    = is_array( $sessions ) ? count( $sessions ) : 0;
+
+    if ( $row_index >= $count ) {
+        // Create a new row with start time so the timer cannot be lost
+        $new_row = [
+            'session_title'           => $session_title,
+            'session_notes'           => '',
+            'session_start_time'      => $current_time,
+            'session_stop_time'       => '',
+            'session_manual_override' => 0,
+            'session_manual_duration' => 0,
+        ];
+        $row_one_based = add_row( 'sessions', $new_row, $post_id ); // returns 1-based index
+        if ( ! $row_one_based ) {
+            wp_send_json_error( [ 'message' => 'Failed to create session row.' ] );
+        }
+        $row_index = intval( $row_one_based ) - 1; // normalize to 0-based for response
+    } else {
+        // Row exists; just set start time and reset stop/duration
+        update_sub_field( [ 'sessions', $row_index + 1, 'session_start_time' ], $current_time, $post_id );
+        update_sub_field( [ 'sessions', $row_index + 1, 'session_stop_time' ], '', $post_id );
+        update_sub_field( [ 'sessions', $row_index + 1, 'session_calculated_duration' ], '0.00', $post_id );
+    }
+
+    // Optionally recalc task totals (safe, cheap)
+    if ( function_exists( 'ptt_calculate_and_save_duration' ) ) { ptt_calculate_and_save_duration( $post_id ); }
+
+    wp_send_json_success( [ 'message' => 'Session started!', 'start_time' => $current_time, 'row_index' => $row_index ] );
 }
 add_action( 'wp_ajax_ptt_start_session_timer', 'ptt_start_session_timer_callback' );
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust Finite State Machine (FSM) centric system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           2.2.32
+ * Version:           2.2.33
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -34,7 +34,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '2.2.32' );
+define( 'PTT_VERSION', '2.2.33' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -2,8 +2,8 @@
 /**
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
- * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           2.2.31
+ * Description:       A robust Finite State Machine (FSM) centric system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
+ * Version:           2.2.32
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -12,12 +12,29 @@
  * Domain Path:       /languages
  */
 
+/**
+ * ========================================================================
+ * AI / LLM AGENT INSTRUCTIONS
+ * ========================================================================
+ * Architectural Pattern: Finite State Machine (FSM)
+ *
+ * This plugin uses an FSM to manage all core business logic and ensure
+ * data integrity. Do not bypass the FSM.
+ *
+ * -   To change an object's state, apply a transition.
+ * -   To perform a CRUD action, tie it to a transition's side-effect.
+ *
+ * Your primary task is to read, understand, and extend the existing
+ * FSM definition when adding or modifying functionality.
+ * ========================================================================
+ */
+
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '2.2.31' );
+define( 'PTT_VERSION', '2.2.32' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/project-task-tracker.php
+++ b/project-task-tracker.php
@@ -3,7 +3,7 @@
  * Plugin Name:       KISS - Project & Task Time Tracker
  * Plugin URI:        https://kissplugins.com
  * Description:       A robust system for WordPress users to track time spent on client projects and individual tasks. Requires ACF Pro.
- * Version:           2.2.29
+ * Version:           2.2.31
  * Author:            KISS Plugins
  * Author URI:        https://kissplugins.com
  * License:           GPL-2.0+
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'PTT_VERSION', '2.2.29' );
+define( 'PTT_VERSION', '2.2.31' );
 define( 'PTT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PTT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/scripts.js
+++ b/scripts.js
@@ -318,6 +318,7 @@ jQuery(document).ready(function ($) {
             const $startInput = $row.find('[data-key="field_ptt_session_start_time"] input');
             const $stopInput = $row.find('[data-key="field_ptt_session_stop_time"] input');
             const $durationInput = $row.find('[data-key="field_ptt_session_calculated_duration"] input');
+            const $manualOverrideInput = $row.find('[data-key="field_ptt_session_manual_override"] input');
 
             const debugEnabled = !!(window.PTT_DEBUG || (window.localStorage && localStorage.getItem('PTT_DEBUG')==='1') || (window.location.search||'').indexOf('ptt_debug=1')>-1);
             const debugHtml = `<div class="ptt-debug" style="margin-top:6px;color:#666;font-size:12px;">[PTT] Timer UI initialized${debugEnabled? ' (debug on)':''}</div>`;
@@ -364,7 +365,7 @@ jQuery(document).ready(function ($) {
 	        const $actions = $field.find('.acf-actions').first();
 	        if ($actions.length) {
 	            if ($actions.find('.ptt-session-update-btn').length === 0) {
-	                const $btn = $('<button type="button" class="button button-secondary ptt-session-update-btn" style="margin-left:8px;">Update</button>');
+	                const $btn = $('<button type="button" class="button button-primary ptt-session-update-btn" style="margin-left:8px;">Update</button>');
 	                $actions.append($btn);
 	            }
 	            return;
@@ -373,7 +374,7 @@ jQuery(document).ready(function ($) {
 	        // Fallback: place after the Add Row button if actions container is not found
 	        const $addBtn = $field.find('[data-event="add-row"], [data-name="add-row"]').last();
 	        if ($addBtn.length && $addBtn.next('.ptt-session-update-btn').length === 0) {
-	            const $btn = $('<button type="button" class="button button-secondary ptt-session-update-btn" style="margin-left:8px;">Update</button>');
+	            const $btn = $('<button type="button" class="button button-primary ptt-session-update-btn" style="margin-left:8px;">Update</button>');
 	            $addBtn.after($btn);
 	        }
 	    }
@@ -386,7 +387,8 @@ jQuery(document).ready(function ($) {
 	    }
 
 	    // Click handler: replicate the Publish/Update button
-	    $(document).on('click', '.ptt-session-update-btn', function(e){
+	    $(document).off('click', '.ptt-session-update-btn');
+    $(document).on('click', '.ptt-session-update-btn', function(e){
 	        e.preventDefault();
 	        const $btn = $(this);
 	        $btn.prop('disabled', true).text('Updating...');
@@ -401,7 +403,18 @@ jQuery(document).ready(function ($) {
                     $startButton.show();
                     $activeDisplay.hide();
                     $message.hide();
+                    const override = $manualOverrideInput.prop('checked');
+                    if (override) {
+                        $startButton.prop('disabled', true).attr('title', 'Manual time entry is enabled for this session.');
+                    } else {
+                        $startButton.prop('disabled', false).removeAttr('title');
+                    }
                 }
+            }
+
+            // React to manual override changes
+            if ($manualOverrideInput && $manualOverrideInput.length) {
+                $manualOverrideInput.on('change', updateUIState);
             }
 
             updateUIState();
@@ -1853,3 +1866,92 @@ jQuery(document).ready(function ($) {
         });
     });
 });
+
+// --- UI Enhancement: Show hh:mm next to Total Duration (hrs) on Task Editor ---
+(function($){
+  function formatHhMmFromDecimalHours(h){
+    if (isNaN(h) || h < 0) { h = 0; }
+    var totalMin = Math.floor(h * 60 + 0.0001); // floor minutes
+    var hh = Math.floor(totalMin / 60);
+    var mm = totalMin % 60;
+    var hhStr = (hh < 10 ? '0' : '') + hh;
+    var mmStr = (mm < 10 ? '0' : '') + mm;
+    return hhStr + ':' + mmStr;
+  }
+  function enhanceTotalDuration(){
+    var $input = $('.acf-field[data-key="field_ptt_total_duration_display"] input[type="text"]');
+    if(!$input.length) return;
+    var $badge = $('<span class="ptt-total-hhmm-badge"></span>');
+    if(!$input.next('.ptt-total-hhmm-badge').length){ $input.after($badge); }
+    else { $badge = $input.next('.ptt-total-hhmm-badge'); }
+    var last = null;
+    function render(){
+      var raw = ($input.val() || '').toString().replace(',', '.');
+      var num = parseFloat(raw);
+      if (isNaN(num)) { $badge.text(''); return; }
+      var hhmm = formatHhMmFromDecimalHours(num);
+      $badge.text('(~' + hhmm + ' hh:mm)');
+    }
+    function tick(){ var cur = $input.val(); if(cur !== last){ last = cur; render(); } }
+    render();
+    $input.on('input change', render);
+    setInterval(tick, 1000);
+  }
+  $(function(){ enhanceTotalDuration(); });
+})(jQuery);
+
+
+// --- Reinforce Sessions "Update" button insertion (robust init + observer) ---
+(function($){
+  function ensureSessionsUpdateButton(ctx){
+    var $root = (ctx && ctx.jquery) ? ctx : $(document);
+    var $field = $root.find('.acf-field[data-key="field_ptt_sessions"]').first();
+    if(!$field.length) return;
+
+    function addIfMissing(){
+      // Preferred: inside .acf-actions
+      var $actions = $field.find('.acf-actions').first();
+      if ($actions.length) {
+        if ($actions.find('.ptt-session-update-btn').length === 0) {
+          $actions.append($('<button type="button" class="button button-primary ptt-session-update-btn" style="margin-left:8px;">Update</button>'));
+        }
+        return;
+      }
+      // Fallback: after Add Row button
+      var $addBtn = $field.find('[data-event="add-row"], [data-name="add-row"], .acf-repeater-add-row').last();
+      if ($addBtn.length && $addBtn.next('.ptt-session-update-btn').length === 0) {
+        $addBtn.after($('<button type="button" class="button button-primary ptt-session-update-btn" style="margin-left:8px;">Update</button>'));
+      }
+    }
+
+    // Initial attempt
+    addIfMissing();
+
+    // Observe DOM changes within the field to re-assert the button
+    try {
+      if (window.MutationObserver) {
+        var obs = new MutationObserver(function(){ addIfMissing(); });
+        obs.observe($field[0], { childList:true, subtree:true });
+      }
+    } catch(e) {}
+
+    // Lightweight periodic retries (10s)
+    var tries = 0; var iv = setInterval(function(){ addIfMissing(); if(++tries >= 10) clearInterval(iv); }, 1000);
+  }
+
+  $(function(){
+    ensureSessionsUpdateButton();
+    if (window.acf) {
+      window.acf.addAction('ready', ensureSessionsUpdateButton);
+      window.acf.addAction('append', ensureSessionsUpdateButton);
+    }
+  });
+
+  // Single delegated handler
+  $(document).on('click', '.ptt-session-update-btn', function(e){
+    e.preventDefault();
+    var $btn = $(this);
+    $btn.prop('disabled', true).text('Updating...');
+    $('#publish').trigger('click');
+  });
+})(jQuery);

--- a/scripts.js
+++ b/scripts.js
@@ -51,6 +51,21 @@ jQuery(document).ready(function ($) {
     // Initial render (safe no-op if panel absent)
     pttUpdateFsmDebug();
 
+        // Short onbeforeunload guard for first 2–3s after starting a timer
+        window.pttStartUnloadGuard = function(ms){
+            try {
+                var duration = ms || 3000;
+                var handler = function(e){
+                    e.preventDefault();
+                    e.returnValue = 'Saving your timer...';
+                    return e.returnValue;
+                };
+                window.addEventListener('beforeunload', handler, { once:false });
+                setTimeout(function(){ window.removeEventListener('beforeunload', handler); }, duration);
+            } catch(_){}
+        };
+
+
 
     // Session recovery - store active task in localStorage
     const PTT_STORAGE_KEY = 'ptt_active_task';
@@ -442,17 +457,31 @@ jQuery(document).ready(function ($) {
         $btn.prop('disabled', true);
         showSpinner($controls);
 
+        var sessionTitle = $row.find('[data-key="field_ptt_session_title"] input').val() || '';
         $.post(ptt_ajax_object.ajax_url, {
             action: 'ptt_start_session_timer',
             nonce: ptt_ajax_object.nonce,
             post_id: postId,
-            row_index: index
+            row_index: index,
+            session_title: sessionTitle
         }).done(function(response){
             if (response.success) {
                 $row.find('[data-key="field_ptt_session_start_time"] input').val(response.data.start_time).trigger('change');
+                if (typeof response.data.row_index !== 'undefined') {
+                    var newIdx = parseInt(response.data.row_index, 10);
+                    if (!isNaN(newIdx) && newIdx !== index) {
+                        window.location.reload();
+                        return;
+                    }
+                }
+
                 $btn.hide();
                 $controls.find('.ptt-session-active-timer').css('display', 'inline-flex');
                 manageLiveTimer($controls, response.data.start_time);
+                if (window.pttStartUnloadGuard) { window.pttStartUnloadGuard(3000); }
+                // Proactively trigger Update to persist any surrounding ACF state
+                var $saveButton = $('#publish');
+                if ($saveButton.length && $saveButton.is(':enabled')) { setTimeout(function(){ $saveButton.trigger('click'); }, 150); }
             } else {
                 alert(response.data.message || 'An error occurred.');
             }

--- a/src/Admin/Assets.php
+++ b/src/Admin/Assets.php
@@ -57,6 +57,10 @@ class Assets {
             'PTT_FSM_TODAY_ENABLED' => $flags['enabled'] && $flags['today'],
             'PTT_FSM_EDITOR_ENABLED' => $flags['enabled'] && $flags['editor'],
         ] );
+        // Mirror flags onto window for legacy scripts that check `window.PTT_FSM_ENABLED`
+        add_action('admin_print_footer_scripts', function() use ($flags){
+            echo '<script>window.PTT_FSM_ENABLED='.( $flags['enabled']? 'true':'false' ).';window.PTT_FSM_TODAY_ENABLED='.( ($flags['enabled']&&$flags['today'])?'true':'false' ).';window.PTT_FSM_EDITOR_ENABLED='.( ($flags['enabled']&&$flags['editor'])?'true':'false' ).';</script>';
+        });
     }
 }
 

--- a/src/Admin/ListTable.php
+++ b/src/Admin/ListTable.php
@@ -1,0 +1,80 @@
+<?php
+namespace KISS\PTT\Admin;
+
+/**
+ * Admin List Table enhancements for project_task CPT.
+ * - Adds sortable Assignee column
+ * - Adds Assignee filter dropdown
+ * - Applies sorting and filtering to main admin list query
+ */
+class ListTable
+{
+    public static function register(): void
+    {
+        add_filter('manage_edit-project_task_sortable_columns', [__CLASS__, 'sortableColumns']);
+        add_action('restrict_manage_posts', [__CLASS__, 'assigneeDropdown']);
+        add_action('pre_get_posts', [__CLASS__, 'handleSortAndFilter']);
+    }
+
+    /**
+     * Mark Assignee column as sortable.
+     */
+    public static function sortableColumns(array $columns): array
+    {
+        $columns['ptt_assignee'] = 'ptt_assignee';
+        return $columns;
+    }
+
+    /**
+     * Render Assignee dropdown on the All Tasks screen.
+     */
+    public static function assigneeDropdown(string $post_type = ''): void
+    {
+        global $typenow;
+        $current = $post_type ?: $typenow;
+        if ($current !== 'project_task') { return; }
+
+        $selected = isset($_GET['ptt_assignee_filter']) ? intval($_GET['ptt_assignee_filter']) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        echo '<label class="screen-reader-text" for="ptt_assignee_filter">Assignee</label>';
+        wp_dropdown_users([
+            'name'            => 'ptt_assignee_filter',
+            'id'              => 'ptt_assignee_filter',
+            'capability'      => 'publish_posts',
+            'show_option_all' => __('All Assignees', 'ptt'),
+            'selected'        => $selected,
+        ]);
+    }
+
+    /**
+     * Apply sorting and filter to the main query.
+     */
+    public static function handleSortAndFilter($query): void
+    {
+        if (!is_admin() || !function_exists('get_current_screen')) { return; }
+        // Only adjust the main list table query for project_task
+        if (!$query->is_main_query()) { return; }
+        $screen = get_current_screen();
+        if (!$screen || $screen->id !== 'edit-project_task') { return; }
+
+        // Sorting by Assignee
+        $orderby = $query->get('orderby');
+        if ($orderby === 'ptt_assignee') {
+            $query->set('meta_key', 'ptt_assignee');
+            $query->set('orderby', 'meta_value_num');
+        }
+
+        // Filtering by Assignee
+        $assignee = isset($_GET['ptt_assignee_filter']) ? intval($_GET['ptt_assignee_filter']) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        if ($assignee) {
+            $meta_query   = (array) $query->get('meta_query');
+            $meta_query[] = [
+                'key'     => 'ptt_assignee',
+                'value'   => $assignee,
+                'compare' => '=',
+                'type'    => 'NUMERIC',
+            ];
+            $query->set('meta_query', $meta_query);
+        }
+    }
+}
+

--- a/src/Diagnostics/SelfTests.php
+++ b/src/Diagnostics/SelfTests.php
@@ -560,6 +560,11 @@ class SelfTests {
             $results[] = [ 'name' => "Database Table: {$name}", 'status' => $table_exists ? 'Pass' : 'Fail', 'message' => $table_exists ? "Database table {$name} exists." : "CRITICAL: Database table {$name} is missing!" ];
         }
 
+        // Admin List Table self-tests (prevent regressions on Assignee sorting/filter)
+        if ( class_exists('KISS\\PTT\\Diagnostics\\SelfTests\\ListTableSelfTests') ) {
+            $results = array_merge($results, \KISS\PTT\Diagnostics\SelfTests\ListTableSelfTests::run());
+        }
+
         // Sample data validation (session-only approach)
         $sample_tasks = get_posts( [ 'post_type' => 'project_task', 'numberposts' => 1, 'post_status' => 'any' ] );
         if ( ! empty( $sample_tasks ) ) {

--- a/src/Diagnostics/SelfTests/ListTableSelfTests.php
+++ b/src/Diagnostics/SelfTests/ListTableSelfTests.php
@@ -1,0 +1,36 @@
+<?php
+namespace KISS\PTT\Diagnostics\SelfTests;
+
+class ListTableSelfTests
+{
+    /**
+     * Verify that Assignee column is sortable and filter exists on All Tasks list.
+     */
+    public static function run(): array
+    {
+        $results = [];
+
+        // Check sortable columns registration
+        $sortable = apply_filters('manage_edit-project_task_sortable_columns', []);
+        $isSortable = isset($sortable['ptt_assignee']);
+        $results[] = [
+            'name' => 'Admin List: Assignee column sortable',
+            'status' => $isSortable ? 'Pass' : 'Fail',
+            'message' => $isSortable ? 'Assignee column is marked sortable.' : 'Assignee column is not marked sortable.'
+        ];
+
+        // Simulate filter presence by executing restrict_manage_posts and capturing output
+        ob_start();
+        do_action('restrict_manage_posts', 'project_task');
+        $html = ob_get_clean();
+        $hasDropdown = (strpos($html, 'ptt_assignee_filter') !== false);
+        $results[] = [
+            'name' => 'Admin List: Assignee filter dropdown',
+            'status' => $hasDropdown ? 'Pass' : 'Fail',
+            'message' => $hasDropdown ? 'Assignee dropdown rendered on list table.' : 'Assignee dropdown not found.'
+        ];
+
+        return $results;
+    }
+}
+

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -52,6 +52,11 @@ class Plugin {
         // PSR-4 migrated: today.php → Presentation\Today\TodayController class with backward compatibility
         require_once PTT_PLUGIN_DIR . 'src/Presentation/Today/today-compat.php';
         require_once PTT_PLUGIN_DIR . 'legacy-core.php';
+        // Editor FSM compat AJAX
+        require_once PTT_PLUGIN_DIR . 'src/Presentation/Editor/editor-compat.php';
+        if (class_exists('KISS\\PTT\\Presentation\\Editor\\EditorCompat')) {
+            \KISS\PTT\Presentation\Editor\EditorCompat::register();
+        }
     }
 
     protected static function register_hooks() {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,6 +12,7 @@ use KISS\PTT\Domain\Timer\TimerService;
 use KISS\PTT\Admin\Assets as AdminAssets;
 use KISS\PTT\Admin\SelfTestController;
 use KISS\PTT\Admin\DataMigrationController;
+use KISS\PTT\Admin\ListTable;
 
 class Plugin {
     // Simple, low-risk: register services directly on Plugin
@@ -31,6 +32,8 @@ class Plugin {
         SelfTestController::register();
         DataMigrationController::register();
         \KISS\PTT\Admin\SchemaStatusPage::register();
+        // Register list table enhancements (sortable/filterable Assignee)
+        if (class_exists('KISS\\PTT\\Admin\\ListTable')) { \KISS\PTT\Admin\ListTable::register(); }
 
         self::register_hooks();
         // Load remaining procedural modules (PSR-4 migration in progress)

--- a/src/Presentation/Editor/editor-compat.php
+++ b/src/Presentation/Editor/editor-compat.php
@@ -1,0 +1,52 @@
+<?php
+namespace KISS\PTT\Presentation\Editor;
+
+/**
+ * Compatibility wrappers and AJAX endpoints for the Post Editor page.
+ * Provides FSM-friendly endpoints to rehydrate an active session for the current user.
+ */
+class EditorCompat
+{
+    public static function register(): void
+    {
+        add_action('wp_ajax_ptt_get_active_session_for_user', [__CLASS__, 'getActiveSessionForUser']);
+    }
+
+    /**
+     * Returns the user's active session across tasks. If found, returns:
+     * { running: true, post_id, session_index, start_time }
+     */
+    public static function getActiveSessionForUser(): void
+    {
+        check_ajax_referer('ptt_ajax_nonce', 'nonce');
+        if (!current_user_can('edit_posts')) {
+            wp_send_json_error(['message' => 'Permission denied.']);
+        }
+
+        $userId = get_current_user_id();
+        if (!$userId || !function_exists('ptt_get_active_session_index_for_user')) {
+            wp_send_json_success(['running' => false]);
+        }
+
+        $active = ptt_get_active_session_index_for_user($userId);
+        if (!$active || empty($active['post_id'])) {
+            wp_send_json_success(['running' => false]);
+        }
+
+        $postId = (int) $active['post_id'];
+        $index0 = (int) $active['index'];
+        $sessions = function_exists('get_field') ? get_field('sessions', $postId) : [];
+        $start = '';
+        if (is_array($sessions) && isset($sessions[$index0])) {
+            $start = $sessions[$index0]['session_start_time'] ?? '';
+        }
+
+        wp_send_json_success([
+            'running' => true,
+            'post_id' => $postId,
+            'session_index' => $index0,
+            'start_time' => $start,
+        ]);
+    }
+}
+

--- a/styles.css
+++ b/styles.css
@@ -99,6 +99,15 @@
 .acf-field[data-key="field_ptt_sessions"] .acf-actions .ptt-session-update-btn {
     margin-left: 0;
     vertical-align: middle;
+
+/* Make the Update button highly visible */
+.acf-field[data-key="field_ptt_sessions"] .ptt-session-update-btn.button.button-primary{
+    background-color: #2271b1; /* WP blue */
+    border-color: #2271b1;
+    box-shadow: 0 1px 0 #2271b1;
+}
+.acf-field[data-key="field_ptt_sessions"] .ptt-session-update-btn{
+    font-weight: 600;
 }
 
 .ptt-session-active-timer {
@@ -109,6 +118,23 @@
 
 .ptt-session-elapsed-time {
     font-family: 'DSEG7Classic-Italic', monospace, sans-serif;
+
+/* Total Duration hh:mm inline badge */
+.acf-field[data-key="field_ptt_total_duration_display"] .acf-input {
+  display: flex;
+  align-items: center;
+  gap: 10px; /* space between input and badge */
+}
+.ptt-total-hhmm-badge{
+  color: #d63638; /* WP error red for emphasis */
+  font-weight: 600;
+  white-space: nowrap;
+}
+/* On small screens, let the badge wrap under nicely */
+@media (max-width: 782px){
+  .acf-field[data-key="field_ptt_total_duration_display"] .acf-input{flex-direction: column; align-items: flex-start; gap: 4px;}
+}
+
     font-size: 1.2em;
     font-weight: bold;
     color: #f44336; /* Red for running timer */


### PR DESCRIPTION
## Version 2.2.31 - Reinforce Update button visibility on Task Editor
- Added robust insertion of an "Update" button next to the Sessions repeater "Add Session" button.
- Uses MutationObserver + periodic retries to ensure the button is present even if ACF renders late.
- Styled as a primary button and placed inline with "Add Session" so it’s easy to find.
- Clicking it triggers the main Publish/Update action (#publish) with disabled state and feedback.